### PR TITLE
Improve Supabase RPC error diagnostics

### DIFF
--- a/src/context/AirQualityContext.tsx
+++ b/src/context/AirQualityContext.tsx
@@ -1,7 +1,11 @@
 import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import { AirQualityData, AirQualityTheme, CityAirQualityData } from '../types';
 import { getAirQualityStatus, getAirQualityTheme } from '../utils/airQualityUtils';
-import { fetchLatestMonterreyAirQuality, MONTERREY_LOCATIONS_WITH_COORDS } from '../services/apiService';
+import {
+  fetchLatestMonterreyAirQuality,
+  isAirQualityServiceError,
+  MONTERREY_LOCATIONS_WITH_COORDS,
+} from '../services/apiService';
 
 type CityOption = (typeof MONTERREY_LOCATIONS_WITH_COORDS)[number];
 
@@ -33,6 +37,23 @@ interface AirQualityProviderProps {
 
 const CACHE_KEY = 'airQualityDataCache';
 const CACHE_EXPIRATION_TIME = 60 * 60 * 1000;
+
+function getRpcFailureReason(error: unknown): string {
+  if (!isAirQualityServiceError(error)) {
+    return 'No se pudo consultar la fuente pública de calidad del aire.';
+  }
+
+  switch (error.code) {
+    case 'supabase_config_missing':
+      return 'El deployment público no tiene configurada la conexión de Supabase.';
+    case 'supabase_rpc_error':
+      return 'Supabase rechazó o no pudo ejecutar la RPC pública de calidad del aire.';
+    case 'supabase_unexpected_response':
+      return 'La RPC de calidad del aire respondió con un formato inesperado.';
+    default:
+      return 'No se pudo consultar la fuente pública de calidad del aire.';
+  }
+}
 
 function buildDegradedAirQualityData(city: CityOption, reason: string): AirQualityData {
   return {
@@ -173,10 +194,7 @@ export function AirQualityProvider({ children }: AirQualityProviderProps) {
       }
     } catch (err) {
       console.error('Error fetching air quality data:', err);
-      const degradedData = buildDegradedAirQualityData(
-        selectedCity,
-        'No se pudo consultar la RPC de calidad del aire.',
-      );
+      const degradedData = buildDegradedAirQualityData(selectedCity, getRpcFailureReason(err));
       setAirQualityData(degradedData);
       setTheme(getAirQualityTheme('unknown'));
       setError('No se pudieron cargar datos frescos de calidad del aire.');

--- a/src/services/apiService.ts
+++ b/src/services/apiService.ts
@@ -4,11 +4,35 @@ import { CityAirQualityData, HistoricalData } from '../types';
 const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL;
 const SUPABASE_ANON_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY;
 
+export type AirQualityServiceErrorCode =
+  | 'supabase_config_missing'
+  | 'supabase_rpc_error'
+  | 'supabase_unexpected_response'
+  | 'unknown_fetch_error';
+
+export class AirQualityServiceError extends Error {
+  code: AirQualityServiceErrorCode;
+
+  constructor(code: AirQualityServiceErrorCode, message: string, cause?: unknown) {
+    super(message);
+    this.name = 'AirQualityServiceError';
+    this.code = code;
+    this.cause = cause;
+  }
+}
+
+export function isAirQualityServiceError(error: unknown): error is AirQualityServiceError {
+  return error instanceof AirQualityServiceError;
+}
+
 let supabaseClient: SupabaseClient | null = null;
 
 const getSupabaseClient = () => {
   if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {
-    throw new Error('La configuración pública de Supabase no está disponible para este deployment.');
+    throw new AirQualityServiceError(
+      'supabase_config_missing',
+      'Falta VITE_SUPABASE_URL o VITE_SUPABASE_ANON_KEY en el deployment público.',
+    );
   }
 
   if (!supabaseClient) {
@@ -37,22 +61,34 @@ export const fetchLatestMonterreyAirQuality = async (): Promise<CityAirQualityDa
 
     if (error) {
       console.error('Error al consultar función de Supabase:', error);
-      throw new Error(`Error al obtener datos de Supabase: ${error.message}`);
+      throw new AirQualityServiceError(
+        'supabase_rpc_error',
+        `No se pudo consultar get_latest_air_quality_per_city: ${error.message}`,
+        error,
+      );
     }
 
     if (!Array.isArray(data)) {
       console.error('Respuesta inesperada de la función de Supabase:', data);
-      throw new Error('La respuesta de Supabase no tiene el formato esperado (no es un array).');
+      throw new AirQualityServiceError(
+        'supabase_unexpected_response',
+        'La respuesta de Supabase no tiene el formato esperado (no es un array).',
+        data,
+      );
     }
 
     return data as CityAirQualityData[];
   } catch (error: unknown) {
+    if (isAirQualityServiceError(error)) {
+      throw error;
+    }
+
     const errorMessage = error instanceof Error
       ? error.message
       : 'Error al obtener los datos de calidad del aire desde Supabase.';
 
     console.error('Detalle del error en fetchLatestMonterreyAirQuality (Supabase):', error);
-    throw new Error(errorMessage);
+    throw new AirQualityServiceError('unknown_fetch_error', errorMessage, error);
   }
 };
 

--- a/src/services/apiService.ts
+++ b/src/services/apiService.ts
@@ -12,12 +12,13 @@ export type AirQualityServiceErrorCode =
 
 export class AirQualityServiceError extends Error {
   code: AirQualityServiceErrorCode;
+  originalError?: unknown;
 
-  constructor(code: AirQualityServiceErrorCode, message: string, cause?: unknown) {
+  constructor(code: AirQualityServiceErrorCode, message: string, originalError?: unknown) {
     super(message);
     this.name = 'AirQualityServiceError';
     this.code = code;
-    this.cause = cause;
+    this.originalError = originalError;
   }
 }
 


### PR DESCRIPTION
## Summary

Small incident-support frontend fix. The current public UI always collapses every Supabase/RPC exception into the same fallback reason: `No se pudo consultar la RPC de calidad del aire.`

This PR keeps the same degraded UI behavior, but classifies the failure source so the public card and console can distinguish:

- missing public Supabase deployment env (`VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY`)
- Supabase RPC execution error (`get_latest_air_quality_per_city` rejected/missing/not granted)
- unexpected RPC response shape
- unknown fetch/network error

## Why

The current screenshot shows global degraded state with the reason `No se pudo consultar la RPC de calidad del aire.` This means the frontend fetch threw before usable rows were returned. That points to frontend/Supabase boundary diagnostics, not only missing pipeline inserts.

## Contract / safety

No changes to:
- RPC name: `get_latest_air_quality_per_city`
- RPC expected payload shape
- Supabase schema
- pipeline repo
- city ids or selector list
- public secret names
- UI layout/redesign

This is diagnostic only and keeps fail-closed degraded behavior.

## Validation

Expected CI:
- `npm run lint`
- `npm run build`

## Post-merge validation

After deploy, hard refresh/incognito on `https://mtyrespira.elelier.com/` and check the degraded reason:

- If it says deployment Supabase config missing: fix Cloudflare Pages env vars.
- If it says Supabase rejected/could not execute RPC: fix Supabase RPC grants/RLS/function existence for anon role.
- If it says unexpected response: inspect RPC return shape.

Also check browser console for the original Supabase error object. No service-role keys or tokens are logged.