### PR TITLE
feat: add RPC-driven AQI metropolitan map

### DIFF
--- a/src/components/AirQualityMap.tsx
+++ b/src/components/AirQualityMap.tsx
@@ -8,7 +8,7 @@ import { getAirQualityStatus, getAirQualityTheme } from '../utils/airQualityUtil
 const MONTERREY_METRO_CENTER: [number, number] = [25.6866, -100.3161];
 const MONTERREY_METRO_ZOOM = 10;
 
-const AQI_LEGEND: Array<{ label: string; range: string; status: AirQualityStatus }> = [
+const AQI_LEGEND: { label: string; range: string; status: AirQualityStatus }[] = [
   { label: 'Buena', range: '0-50', status: 'good' },
   { label: 'Moderada', range: '51-100', status: 'moderate' },
   { label: 'Dañina a sensibles', range: '101-150', status: 'unhealthy-sensitive' },

--- a/src/components/AirQualityMap.tsx
+++ b/src/components/AirQualityMap.tsx
@@ -8,14 +8,19 @@ import { getAirQualityStatus, getAirQualityTheme } from '../utils/airQualityUtil
 const MONTERREY_METRO_CENTER: [number, number] = [25.6866, -100.3161];
 const MONTERREY_METRO_ZOOM = 10;
 
-const AQI_LEGEND: { label: string; range: string; status: AirQualityStatus }[] = [
-  { label: 'Buena', range: '0-50', status: 'good' },
-  { label: 'Moderada', range: '51-100', status: 'moderate' },
-  { label: 'Dañina a sensibles', range: '101-150', status: 'unhealthy-sensitive' },
-  { label: 'Dañina', range: '151-200', status: 'unhealthy' },
-  { label: 'Muy dañina', range: '201-300', status: 'very-unhealthy' },
-  { label: 'Peligrosa', range: '301+', status: 'hazardous' },
-  { label: 'Sin lectura', range: 'N/D', status: 'unknown' },
+const AQI_LEGEND: { label: string; shortLabel: string; range: string; status: AirQualityStatus }[] = [
+  { label: 'Buena', shortLabel: 'Buena', range: '0-50', status: 'good' },
+  { label: 'Moderada', shortLabel: 'Mod.', range: '51-100', status: 'moderate' },
+  {
+    label: 'Dañina a sensibles',
+    shortLabel: 'Sensibles',
+    range: '101-150',
+    status: 'unhealthy-sensitive',
+  },
+  { label: 'Dañina', shortLabel: 'Dañina', range: '151-200', status: 'unhealthy' },
+  { label: 'Muy dañina', shortLabel: 'Muy dañina', range: '201-300', status: 'very-unhealthy' },
+  { label: 'Peligrosa', shortLabel: 'Peligrosa', range: '301+', status: 'hazardous' },
+  { label: 'Sin lectura', shortLabel: 'Sin lectura', range: 'N/D', status: 'unknown' },
 ];
 
 const STATUS_LABELS: Record<AirQualityStatus, string> = {
@@ -37,19 +42,18 @@ function hasValidCoordinates(row: CityAirQualityData) {
   );
 }
 
-function formatTimestamp(timestamp: string | null | undefined) {
+function formatTime(timestamp: string | null | undefined) {
   if (!timestamp) {
-    return 'No disponible';
+    return 'N/D';
   }
 
   const parsedDate = new Date(timestamp);
 
   if (Number.isNaN(parsedDate.getTime())) {
-    return 'No disponible';
+    return 'N/D';
   }
 
   return parsedDate.toLocaleString('es-MX', {
-    dateStyle: 'medium',
     timeStyle: 'short',
   });
 }
@@ -104,6 +108,10 @@ export default function AirQualityMap() {
   const { cityRows, cityOptions, selectedCity, changeCity } = useAirQuality();
   const rowsWithCoordinates = cityRows.filter(hasValidCoordinates);
   const rowsWithoutCoordinates = cityRows.length - rowsWithCoordinates.length;
+  const selectedRow = rowsWithCoordinates.find((row) => row.city_id === selectedCity.city_id)
+    ?? rowsWithCoordinates[0];
+  const selectedStatus = getAirQualityStatus(selectedRow?.aqi_us);
+  const selectedTheme = getAirQualityTheme(selectedStatus);
 
   if (cityRows.length === 0) {
     return (
@@ -141,27 +149,24 @@ export default function AirQualityMap() {
   return (
     <section
       aria-labelledby="aqi-map-title"
-      className="overflow-hidden rounded-xl border border-slate-200 bg-white shadow-lg dark:border-slate-700 dark:bg-slate-800"
+      className="space-y-4 rounded-xl border border-slate-200 bg-white p-4 shadow-lg dark:border-slate-700 dark:bg-slate-800 sm:p-5"
     >
-      <div className="p-5">
-        <div className="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
-          <div>
-            <h2 id="aqi-map-title" className="text-xl font-bold text-gray-900 dark:text-white">
-              Mapa metropolitano AQI
-            </h2>
-            <p className="mt-1 text-sm text-gray-600 dark:text-gray-300">
-              Toca un municipio para ver sus detalles y actualizar la tarjeta principal.
-            </p>
-          </div>
-          {rowsWithoutCoordinates > 0 && (
-            <p className="rounded-lg border border-amber-300 bg-amber-50 px-3 py-2 text-xs text-amber-800">
-              {rowsWithoutCoordinates} municipio(s) sin coordenadas en RPC.
-            </p>
-          )}
-        </div>
+      <div>
+        <h2 id="aqi-map-title" className="text-xl font-bold text-gray-900 dark:text-white">
+          Mapa metropolitano AQI
+        </h2>
+        <p className="mt-1 text-sm text-gray-600 dark:text-gray-300">
+          Toca un municipio para ver sus detalles y actualizar la tarjeta principal.
+        </p>
       </div>
 
-      <div className="h-[360px] w-full md:h-[430px]">
+      {rowsWithoutCoordinates > 0 && (
+        <p className="rounded-lg border border-amber-300 bg-amber-50 px-3 py-2 text-xs text-amber-800">
+          {rowsWithoutCoordinates} municipio(s) sin coordenadas en RPC.
+        </p>
+      )}
+
+      <div className="h-[330px] w-full overflow-hidden rounded-2xl md:h-[430px]">
         <MapContainer
           center={MONTERREY_METRO_CENTER}
           className="h-full w-full"
@@ -195,31 +200,17 @@ export default function AirQualityMap() {
                 }}
                 radius={getMarkerRadius(row)}
               >
-                <Popup>
-                  <div className="max-w-[220px] text-sm text-slate-800">
-                    <p className="text-base font-semibold">{row.city_name}</p>
-                    <dl className="mt-2 space-y-1">
-                      <div>
-                        <dt className="inline font-semibold">AQI: </dt>
-                        <dd className="inline">{row.aqi_us ?? 'No disponible'}</dd>
-                      </div>
-                      <div>
-                        <dt className="inline font-semibold">Categoría: </dt>
-                        <dd className="inline">{STATUS_LABELS[status]}</dd>
-                      </div>
-                      <div>
-                        <dt className="inline font-semibold">Contaminante: </dt>
-                        <dd className="inline">{getPollutantLabel(row.main_pollutant_us)}</dd>
-                      </div>
-                      <div>
-                        <dt className="inline font-semibold">Medición tomada: </dt>
-                        <dd className="inline">{formatTimestamp(row.reading_timestamp)}</dd>
-                      </div>
-                      <div>
-                        <dt className="inline font-semibold">Actualizado en MtyRespira: </dt>
-                        <dd className="inline">{formatTimestamp(row.last_successful_update_at)}</dd>
-                      </div>
-                    </dl>
+                <Popup keepInView maxWidth={210} minWidth={150}>
+                  <div className="max-w-[170px] text-xs text-slate-800">
+                    <p className="text-sm font-semibold leading-tight">{row.city_name}</p>
+                    <p className="mt-1 font-semibold">
+                      AQI {row.aqi_us ?? 'N/D'} · {STATUS_LABELS[status]}
+                    </p>
+                    <p className="mt-1">{getPollutantLabel(row.main_pollutant_us)}</p>
+                    <p className="mt-1 text-slate-600">
+                      Medición {formatTime(row.reading_timestamp)} · Act.{' '}
+                      {formatTime(row.last_successful_update_at)}
+                    </p>
                   </div>
                 </Popup>
               </CircleMarker>
@@ -228,26 +219,77 @@ export default function AirQualityMap() {
         </MapContainer>
       </div>
 
-      <div className="border-t border-slate-200 p-5 dark:border-slate-700">
-        <h3 className="text-sm font-semibold text-gray-900 dark:text-white">Leyenda AQI US</h3>
-        <ul className="mt-3 grid grid-cols-1 gap-2 text-xs text-gray-700 dark:text-gray-300 sm:grid-cols-2 lg:grid-cols-4">
+      {selectedRow && (
+        <article className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-700 dark:bg-slate-900">
+          <h3 className="text-lg font-bold leading-tight text-gray-900 dark:text-white">
+            {selectedRow.city_name}
+          </h3>
+          <div className="mt-2 flex flex-wrap gap-2">
+            <span
+              className="rounded-lg border px-2.5 py-1 text-lg font-bold"
+              style={{ borderColor: selectedTheme.primary, color: selectedTheme.text }}
+            >
+              AQI {selectedRow.aqi_us ?? 'N/D'}
+            </span>
+            <span
+              className="rounded-lg border px-2.5 py-1 text-sm font-semibold"
+              style={{ borderColor: selectedTheme.primary, color: selectedTheme.text }}
+            >
+              {STATUS_LABELS[selectedStatus]}
+            </span>
+          </div>
+
+          <dl className="mt-4 grid grid-cols-2 gap-3 border-t border-slate-200 pt-4 text-sm dark:border-slate-700 sm:grid-cols-4">
+            <div>
+              <dt className="text-gray-500 dark:text-gray-400">Contaminante</dt>
+              <dd className="font-semibold text-gray-900 dark:text-white">
+                {getPollutantLabel(selectedRow.main_pollutant_us)}
+              </dd>
+            </div>
+            <div>
+              <dt className="text-gray-500 dark:text-gray-400">Medición</dt>
+              <dd className="font-semibold text-gray-900 dark:text-white">
+                {formatTime(selectedRow.reading_timestamp)}
+              </dd>
+            </div>
+            <div>
+              <dt className="text-gray-500 dark:text-gray-400">Actualizado</dt>
+              <dd className="font-semibold text-gray-900 dark:text-white">
+                {formatTime(selectedRow.last_successful_update_at)}
+              </dd>
+            </div>
+            <div>
+              <dt className="text-gray-500 dark:text-gray-400">Fuente</dt>
+              <dd className="font-semibold text-gray-900 dark:text-white">MtyRespira</dd>
+            </div>
+          </dl>
+        </article>
+      )}
+
+      <div className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-700 dark:bg-slate-900">
+        <h3 className="text-base font-bold text-gray-900 dark:text-white">Escala AQI (US)</h3>
+        <div className="mt-3 grid grid-cols-2 gap-2 text-center text-xs sm:grid-cols-4 lg:grid-cols-7">
           {AQI_LEGEND.map((item) => {
             const theme = getAirQualityTheme(item.status);
 
             return (
-              <li className="flex items-center gap-2" key={item.status}>
-                <span
-                  aria-hidden="true"
-                  className="h-3 w-3 rounded-full border border-slate-500/30"
+              <div key={item.status}>
+                <div
+                  className="rounded-lg px-2 py-1.5 font-bold text-white"
                   style={{ backgroundColor: theme.primary }}
-                />
-                <span>
-                  <strong>{item.label}</strong> · {item.range}
-                </span>
-              </li>
+                >
+                  {item.range}
+                </div>
+                <p className="mt-1 font-medium text-gray-700 dark:text-gray-300">
+                  {item.shortLabel}
+                </p>
+              </div>
             );
           })}
-        </ul>
+        </div>
+        <p className="mt-3 text-xs text-gray-500 dark:text-gray-400">
+          AQI: Índice de Calidad del Aire bajo escala US EPA.
+        </p>
       </div>
     </section>
   );

--- a/src/components/AirQualityMap.tsx
+++ b/src/components/AirQualityMap.tsx
@@ -150,8 +150,7 @@ export default function AirQualityMap() {
               Mapa metropolitano AQI
             </h2>
             <p className="mt-1 text-sm text-gray-600 dark:text-gray-300">
-              Pins generados desde la RPC actual. Haz clic en un municipio para actualizar la
-              tarjeta principal.
+              Toca un municipio para ver sus detalles y actualizar la tarjeta principal.
             </p>
           </div>
           {rowsWithoutCoordinates > 0 && (

--- a/src/components/AirQualityMap.tsx
+++ b/src/components/AirQualityMap.tsx
@@ -1,22 +1,255 @@
-import React from 'react';
-import CityMapPlaceholder from './CityMapPlaceholder';
+import 'leaflet/dist/leaflet.css';
 
-// Este componente es simplemente un wrapper alrededor de CityMapPlaceholder
-// para mantener compatibilidad con el código existente pero evitar errores de compilación
-interface AirQualityMapProps {
-  className?: string;
-  center?: [number, number];
+import { CircleMarker, MapContainer, Popup, TileLayer } from 'react-leaflet';
+import { useAirQuality } from '../context/AirQualityContext';
+import { AirQualityStatus, CityAirQualityData, CitySelectorOption } from '../types';
+import { getAirQualityStatus, getAirQualityTheme } from '../utils/airQualityUtils';
+
+const MONTERREY_METRO_CENTER: [number, number] = [25.6866, -100.3161];
+const MONTERREY_METRO_ZOOM = 10;
+
+const AQI_LEGEND: Array<{ label: string; range: string; status: AirQualityStatus }> = [
+  { label: 'Buena', range: '0-50', status: 'good' },
+  { label: 'Moderada', range: '51-100', status: 'moderate' },
+  { label: 'Dañina a sensibles', range: '101-150', status: 'unhealthy-sensitive' },
+  { label: 'Dañina', range: '151-200', status: 'unhealthy' },
+  { label: 'Muy dañina', range: '201-300', status: 'very-unhealthy' },
+  { label: 'Peligrosa', range: '301+', status: 'hazardous' },
+  { label: 'Sin lectura', range: 'N/D', status: 'unknown' },
+];
+
+const STATUS_LABELS: Record<AirQualityStatus, string> = {
+  good: 'Buena',
+  moderate: 'Moderada',
+  'unhealthy-sensitive': 'Dañina para grupos sensibles',
+  unhealthy: 'Dañina',
+  'very-unhealthy': 'Muy dañina',
+  hazardous: 'Peligrosa',
+  unknown: 'Sin lectura confiable',
+};
+
+function hasValidCoordinates(row: CityAirQualityData) {
+  return (
+    typeof row.latitude === 'number'
+    && Number.isFinite(row.latitude)
+    && typeof row.longitude === 'number'
+    && Number.isFinite(row.longitude)
+  );
 }
 
-export default function AirQualityMap({ className = '', center = [25.6866, -100.3161] }: AirQualityMapProps) {
-  // Extraer el nombre de la ciudad basado en las coordenadas centrales (aproximado)
-  const getCityNameFromCoordinates = (coords: [number, number]): string => {
-    // Simplemente devolvemos "Monterrey Centro" como ciudad predeterminada
-    // En una implementación real, buscaríamos la ciudad más cercana a las coordenadas
-    return "Monterrey Centro";
+function formatTimestamp(timestamp: string | null | undefined) {
+  if (!timestamp) {
+    return 'No disponible';
+  }
+
+  const parsedDate = new Date(timestamp);
+
+  if (Number.isNaN(parsedDate.getTime())) {
+    return 'No disponible';
+  }
+
+  return parsedDate.toLocaleString('es-MX', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  });
+}
+
+function getPollutantLabel(pollutant: string | null) {
+  if (!pollutant) {
+    return 'No disponible';
+  }
+
+  const normalizedPollutant = pollutant.toLowerCase();
+
+  switch (normalizedPollutant) {
+    case 'p2':
+    case 'pm25':
+      return 'PM2.5';
+    case 'p1':
+    case 'pm10':
+      return 'PM10';
+    case 'o3':
+      return 'O₃';
+    case 'no2':
+      return 'NO₂';
+    case 'so2':
+      return 'SO₂';
+    case 'co':
+      return 'CO';
+    default:
+      return pollutant.toUpperCase();
+  }
+}
+
+function getMarkerRadius(row: CityAirQualityData) {
+  if (row.aqi_us === null) {
+    return 11;
+  }
+
+  return row.aqi_us > 150 ? 15 : 12;
+}
+
+function getCityOption(row: CityAirQualityData, cityOptions: CitySelectorOption[]) {
+  const matchedOption = cityOptions.find((option) => option.city_id === row.city_id);
+
+  return matchedOption ?? {
+    city_id: row.city_id,
+    name: row.city_name,
+    latitude: row.latitude ?? MONTERREY_METRO_CENTER[0],
+    longitude: row.longitude ?? MONTERREY_METRO_CENTER[1],
   };
+}
 
-  const cityName = getCityNameFromCoordinates(center);
+export default function AirQualityMap() {
+  const { cityRows, cityOptions, selectedCity, changeCity } = useAirQuality();
+  const rowsWithCoordinates = cityRows.filter(hasValidCoordinates);
+  const rowsWithoutCoordinates = cityRows.length - rowsWithCoordinates.length;
 
-  return <CityMapPlaceholder className={className} selectedCityName={cityName} />;
+  if (cityRows.length === 0) {
+    return (
+      <section
+        aria-labelledby="aqi-map-title"
+        className="rounded-xl border border-slate-200 bg-white p-5 shadow-lg dark:border-slate-700 dark:bg-slate-800"
+      >
+        <h2 id="aqi-map-title" className="text-xl font-bold text-gray-900 dark:text-white">
+          Mapa metropolitano AQI
+        </h2>
+        <p className="mt-2 text-sm text-gray-600 dark:text-gray-300">
+          El mapa se mostrará cuando la RPC pública devuelva municipios con coordenadas válidas.
+        </p>
+      </section>
+    );
+  }
+
+  if (rowsWithCoordinates.length === 0) {
+    return (
+      <section
+        aria-labelledby="aqi-map-title"
+        className="rounded-xl border border-amber-300 bg-amber-50 p-5 text-amber-900 shadow-lg"
+      >
+        <h2 id="aqi-map-title" className="text-xl font-bold">
+          Mapa metropolitano AQI
+        </h2>
+        <p className="mt-2 text-sm">
+          La RPC devolvió datos, pero ninguna ciudad incluye latitude/longitude válidas. No se
+          muestran ubicaciones estimadas.
+        </p>
+      </section>
+    );
+  }
+
+  return (
+    <section
+      aria-labelledby="aqi-map-title"
+      className="overflow-hidden rounded-xl border border-slate-200 bg-white shadow-lg dark:border-slate-700 dark:bg-slate-800"
+    >
+      <div className="p-5">
+        <div className="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
+          <div>
+            <h2 id="aqi-map-title" className="text-xl font-bold text-gray-900 dark:text-white">
+              Mapa metropolitano AQI
+            </h2>
+            <p className="mt-1 text-sm text-gray-600 dark:text-gray-300">
+              Pins generados desde la RPC actual. Haz clic en un municipio para actualizar la
+              tarjeta principal.
+            </p>
+          </div>
+          {rowsWithoutCoordinates > 0 && (
+            <p className="rounded-lg border border-amber-300 bg-amber-50 px-3 py-2 text-xs text-amber-800">
+              {rowsWithoutCoordinates} municipio(s) sin coordenadas en RPC.
+            </p>
+          )}
+        </div>
+      </div>
+
+      <div className="h-[360px] w-full md:h-[430px]">
+        <MapContainer
+          center={MONTERREY_METRO_CENTER}
+          className="h-full w-full"
+          scrollWheelZoom={false}
+          zoom={MONTERREY_METRO_ZOOM}
+        >
+          <TileLayer
+            attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+            url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+          />
+
+          {rowsWithCoordinates.map((row) => {
+            const status = getAirQualityStatus(row.aqi_us);
+            const theme = getAirQualityTheme(status);
+            const isSelected = selectedCity.city_id === row.city_id;
+            const cityOption = getCityOption(row, cityOptions);
+
+            return (
+              <CircleMarker
+                center={[row.latitude as number, row.longitude as number]}
+                eventHandlers={{
+                  click: () => changeCity(cityOption),
+                }}
+                key={row.city_id}
+                pathOptions={{
+                  color: isSelected ? '#0f172a' : theme.secondary,
+                  fillColor: theme.primary,
+                  fillOpacity: 0.78,
+                  opacity: 0.95,
+                  weight: isSelected ? 3 : 2,
+                }}
+                radius={getMarkerRadius(row)}
+              >
+                <Popup>
+                  <div className="max-w-[220px] text-sm text-slate-800">
+                    <p className="text-base font-semibold">{row.city_name}</p>
+                    <dl className="mt-2 space-y-1">
+                      <div>
+                        <dt className="inline font-semibold">AQI: </dt>
+                        <dd className="inline">{row.aqi_us ?? 'No disponible'}</dd>
+                      </div>
+                      <div>
+                        <dt className="inline font-semibold">Categoría: </dt>
+                        <dd className="inline">{STATUS_LABELS[status]}</dd>
+                      </div>
+                      <div>
+                        <dt className="inline font-semibold">Contaminante: </dt>
+                        <dd className="inline">{getPollutantLabel(row.main_pollutant_us)}</dd>
+                      </div>
+                      <div>
+                        <dt className="inline font-semibold">Medición: </dt>
+                        <dd className="inline">{formatTimestamp(row.reading_timestamp)}</dd>
+                      </div>
+                      <div>
+                        <dt className="inline font-semibold">Último éxito pipeline: </dt>
+                        <dd className="inline">{formatTimestamp(row.last_successful_update_at)}</dd>
+                      </div>
+                    </dl>
+                  </div>
+                </Popup>
+              </CircleMarker>
+            );
+          })}
+        </MapContainer>
+      </div>
+
+      <div className="border-t border-slate-200 p-5 dark:border-slate-700">
+        <h3 className="text-sm font-semibold text-gray-900 dark:text-white">Leyenda AQI US</h3>
+        <ul className="mt-3 grid grid-cols-1 gap-2 text-xs text-gray-700 dark:text-gray-300 sm:grid-cols-2 lg:grid-cols-4">
+          {AQI_LEGEND.map((item) => {
+            const theme = getAirQualityTheme(item.status);
+
+            return (
+              <li className="flex items-center gap-2" key={item.status}>
+                <span
+                  aria-hidden="true"
+                  className="h-3 w-3 rounded-full border border-slate-500/30"
+                  style={{ backgroundColor: theme.primary }}
+                />
+                <span>
+                  <strong>{item.label}</strong> · {item.range}
+                </span>
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+    </section>
+  );
 }

--- a/src/components/AirQualityMap.tsx
+++ b/src/components/AirQualityMap.tsx
@@ -217,7 +217,7 @@ export default function AirQualityMap() {
                         <dd className="inline">{formatTimestamp(row.reading_timestamp)}</dd>
                       </div>
                       <div>
-                        <dt className="inline font-semibold">Último éxito pipeline: </dt>
+                        <dt className="inline font-semibold">Datos actualizados: </dt>
                         <dd className="inline">{formatTimestamp(row.last_successful_update_at)}</dd>
                       </div>
                     </dl>

--- a/src/components/AirQualityMap.tsx
+++ b/src/components/AirQualityMap.tsx
@@ -213,11 +213,11 @@ export default function AirQualityMap() {
                         <dd className="inline">{getPollutantLabel(row.main_pollutant_us)}</dd>
                       </div>
                       <div>
-                        <dt className="inline font-semibold">Medición: </dt>
+                        <dt className="inline font-semibold">Medición tomada: </dt>
                         <dd className="inline">{formatTimestamp(row.reading_timestamp)}</dd>
                       </div>
                       <div>
-                        <dt className="inline font-semibold">Datos actualizados: </dt>
+                        <dt className="inline font-semibold">Actualizado en MtyRespira: </dt>
                         <dd className="inline">{formatTimestamp(row.last_successful_update_at)}</dd>
                       </div>
                     </dl>

--- a/src/context/AirQualityContext.tsx
+++ b/src/context/AirQualityContext.tsx
@@ -23,6 +23,7 @@ interface AirQualityContextType {
   refreshData: () => Promise<void>;
   selectedCity: CityOption;
   cityOptions: CitySelectorOption[];
+  cityRows: CityAirQualityData[];
   changeCity: (city: CityOption) => void;
 }
 
@@ -316,6 +317,7 @@ export function AirQualityProvider({ children }: AirQualityProviderProps) {
     refreshData,
     selectedCity,
     cityOptions,
+    cityRows: cityDataArray,
     changeCity,
   };
 

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -7,11 +7,11 @@ import Recommendations from '../components/Recommendations';
 //import HistoricalChart from '../components/HistoricalChart';
 //import PollutantsInfo from '../components/PollutantsInfo';
 import CitySelector from '../components/CitySelector';
+import AirQualityMap from '../components/AirQualityMap';
 //import StationMap from '../components/StationMap';
 //import AirQualityHeatmap from '../components/AirQualityHeatmap';
 //import PollutantConcentrationMap from '../components/PollutantConcentrationMap';
 //import CityMapPlaceholder from '../components/CityMapPlaceholder';
-import { useEffect, useState } from 'react';
 import { motion } from 'framer-motion';
 import { IoArrowForwardOutline, IoEarthOutline, IoLeafOutline, IoHelpBuoyOutline } from 'react-icons/io5';
 
@@ -26,24 +26,6 @@ export default function Dashboard() {
     selectedCity,
     cityOptions,
   } = useAirQuality();
-  const [, setUseStaticMap] = useState(false);
-
-  // Manejar errores en la carga del mapa
-  useEffect(() => {
-    const handleMapError = (event: ErrorEvent) => {
-      // Si hay un error relacionado con Leaflet o mapas, cambiamos al placeholder
-      if (event.message.includes('Leaflet') || event.filename?.includes('leaflet')) {
-        console.warn('Error con el mapa: ', event.message);
-        setUseStaticMap(true);
-      }
-    };
-
-    window.addEventListener('error', handleMapError);
-
-    return () => {
-      window.removeEventListener('error', handleMapError);
-    };
-  }, []);
 
   // Obtener estilos de color basados en la calidad del aire
   const getStatusButtonClass = () => {
@@ -178,6 +160,10 @@ export default function Dashboard() {
           {/* Recomendaciones basadas en la calidad del aire */}
           <Recommendations status={airQualityData.status} />
         </div>
+      </div>
+
+      <div className="mt-6">
+        <AirQualityMap />
       </div>
 
       {/* CTA para asociaciones */}


### PR DESCRIPTION
## Impacto

Agrega un mapa metropolitano AQI en Dashboard/Home usando Leaflet/React-Leaflet y exclusivamente las filas ya obtenidas desde `AirQualityContext`.

- Reusa el array actual de la RPC `get_latest_air_quality_per_city`; no agrega fetch directo a Supabase desde el mapa.
- Expone `cityRows` desde `AirQualityContext` sin romper la API existente.
- Renderiza pins solo para ciudades con `latitude/longitude` válidas.
- Click en pin llama `changeCity(...)` y actualiza la tarjeta AQI existente.
- Popup muestra ciudad, AQI, categoría, contaminante, hora de medición y último éxito del pipeline.
- Incluye leyenda AQI accesible con texto + color.
- Degrada honestamente si la RPC no trae filas o si faltan coordenadas.

## Archivos tocados

- `src/context/AirQualityContext.tsx`
- `src/components/AirQualityMap.tsx`
- `src/pages/Dashboard.tsx`

## Supabase manual validation

El usuario validó manualmente en Supabase:

### Ciudades activas + coordenadas

```sql
select
  id as city_id,
  name,
  api_name,
  is_active,
  latitude,
  longitude,
  last_successful_update_at,
  last_update_status
from public.cities
where is_active = true
order by id;
```

Resultado: 9 ciudades activas con coordenadas válidas.

### Payload RPC real

```sql
select *
from public.get_latest_air_quality_per_city()
order by city_id;
```

Resultado: 9 filas con `city_id`, `city_name`, `latitude`, `longitude`, `reading_timestamp`, `aqi_us`, `main_pollutant_us`, clima parcial y `last_successful_update_at`.

### Diagnóstico compacto para mapa

```sql
select
  city_id,
  city_name,
  api_name,
  aqi_us,
  main_pollutant_us,
  reading_timestamp,
  last_successful_update_at,
  case
    when latitude is null or longitude is null then 'sin_coordenadas'
    when aqi_us is null then 'sin_aqi'
    when reading_timestamp is null then 'sin_timestamp_medicion'
    when last_successful_update_at is null then 'sin_timestamp_pipeline'
    else 'ok'
  end as map_readiness
from public.get_latest_air_quality_per_city()
order by city_id;
```

Resultado: las 9 filas `map_readiness = ok`.

Nota operativa: San Nicolas de los Garza tiene `cities.last_update_status = error: missing_aqi`, pero la RPC conserva una lectura previa válida (`aqi_us = 108`, `reading_timestamp = 2026-05-07 19:00:00+00`). El mapa representa la lectura disponible sin inventar frescura adicional.

## Checks

Pendientes de CI/runner:

```bash
npm run lint
npx tsc --noEmit
npm run build
```

## Rollback

Revertir este PR restaura el placeholder/wrapper previo de `AirQualityMap`, elimina la integración visual del mapa en Dashboard y deja intacto el contrato `pipeline -> Supabase -> RPC -> frontend`.