### PR TITLE
fix: keep city selector above AQI map

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -131,7 +131,7 @@ export default function Dashboard() {
   return (
     <Layout>
       {/* Selector de ciudad */}
-      <div className="relative sticky top-[65px] z-10 mb-5 py-5">
+      <div className="relative sticky top-[65px] z-[1000] mb-5 py-5">
         <div className="pointer-events-none absolute inset-x-0 top-0 z-[-1] h-12 bg-gradient-to-b from-white/70 to-transparent backdrop-blur-md" />
         <CitySelector
           onCityChange={changeCity}
@@ -162,7 +162,7 @@ export default function Dashboard() {
         </div>
       </div>
 
-      <div className="mt-6">
+      <div className="relative z-0 mt-6">
         <AirQualityMap />
       </div>
 


### PR DESCRIPTION
## Impacto

Corrige el problema de stacking donde Leaflet/mapa se montaba por arriba del selector de ciudad sticky durante scroll en mobile.

## Cambio

- Sube el selector sticky de `z-10` a `z-[1000]`.
- Envuelve `AirQualityMap` en un contenedor `relative z-0` para mantenerlo por debajo del selector.
- No toca Supabase, RPC, pipeline, datos ni contrato.

## Checks

Esperado por CI:

```bash
npm run lint
npx tsc --noEmit
npm run build
```

## Rollback

Revertir este PR restaura los z-index previos. No afecta datos, rutas ni contrato `pipeline -> Supabase -> RPC -> frontend`.