### PR TITLE
feat: add historical city trend MVP

### DIFF
--- a/docs/shared-data-contract.md
+++ b/docs/shared-data-contract.md
@@ -30,9 +30,9 @@ When implementation, docs, tests, and runtime disagree, use this order:
     - `utils.py`
     - `.github/workflows/air-quality-workflow.yml`
 
-## Critical RPC
+## Critical latest RPC
 
-The frontend consumes this Supabase RPC directly:
+The frontend consumes this Supabase RPC directly for the current dashboard:
 
 ```ts
 supabase.rpc('get_latest_air_quality_per_city')
@@ -40,7 +40,66 @@ supabase.rpc('get_latest_air_quality_per_city')
 
 Compatibility rule: do not rename it, remove output fields, change timestamp semantics, or change one-row-per-active-city behavior without a coordinated rollout.
 
-## Canonical RPC payload
+## Additive history RPC
+
+The frontend may consume this additive Supabase RPC for historical city trends:
+
+```ts
+supabase.rpc('get_air_quality_history_for_city', {
+  p_city_id: cityId,
+  p_hours: hours,
+})
+```
+
+Compatibility rule: this RPC is additive and must not replace or modify `get_latest_air_quality_per_city`.
+
+Manual SQL to create or replace the function:
+
+```sql
+create or replace function public.get_air_quality_history_for_city(
+  p_city_id bigint,
+  p_hours integer default 24
+)
+returns table (
+  city_id bigint,
+  city_name text,
+  reading_timestamp timestamptz,
+  aqi_us smallint,
+  main_pollutant_us text,
+  temperature_c real,
+  humidity_percent smallint
+)
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select
+    c.id as city_id,
+    c.name as city_name,
+    r.reading_timestamp,
+    r.aqi_us,
+    r.main_pollutant_us,
+    r.temperature_c,
+    r.humidity_percent
+  from public.air_quality_readings r
+  join public.cities c on c.id = r.city_id
+  where c.id = p_city_id
+    and c.is_active = true
+    and r.reading_timestamp >= now() - make_interval(hours => greatest(1, least(coalesce(p_hours, 24), 24 * 14)))
+  order by r.reading_timestamp asc;
+$$;
+
+grant execute on function public.get_air_quality_history_for_city(bigint, integer) to anon, authenticated;
+```
+
+Rollback SQL:
+
+```sql
+drop function if exists public.get_air_quality_history_for_city(bigint, integer);
+```
+
+## Canonical latest RPC payload
 
 The frontend expects an array compatible with this shape:
 
@@ -65,6 +124,24 @@ The frontend expects an array compatible with this shape:
 ]
 ```
 
+## Canonical history RPC payload
+
+The history RPC returns rows ordered by `reading_timestamp` ascending:
+
+```jsonc
+[
+  {
+    "city_id": 9,
+    "city_name": "Monterrey",
+    "reading_timestamp": "2026-01-01T00:00:00+00:00",
+    "aqi_us": 75,
+    "main_pollutant_us": "p2",
+    "temperature_c": 23,
+    "humidity_percent": 45
+  }
+]
+```
+
 ## Field contract
 
 | Field | TypeScript expectation | Nullability rule | Notes |
@@ -75,7 +152,7 @@ The frontend expects an array compatible with this shape:
 | `latitude` | `number \| null` | nullable | Frontend falls back to static city coordinates if null. |
 | `longitude` | `number \| null` | nullable | Frontend falls back to static city coordinates if null. |
 | `reading_timestamp` | `string` | required | Source measurement time. Treat as UTC. |
-| `aqi_us` | `number \| null` | nullable | If null, frontend must degrade to `unknown`. |
+| `aqi_us` | `number \| null` | nullable | If null, frontend must degrade to `unknown`. History chart excludes null AQI rows. |
 | `main_pollutant_us` | `string \| null` | nullable | UI shows `N/D` if missing. |
 | `temperature_c` | `number \| null` | nullable | UI shows `N/D` if missing. |
 | `humidity_percent` | `number \| null` | nullable | UI shows `N/D` if missing. |
@@ -99,14 +176,16 @@ Rules:
 - `last_successful_update_at` is pipeline write success time.
 - The UI must not imply stronger freshness than the hourly producer cadence.
 - If data is missing, stale, nullable in critical fields, or contract-invalid, the frontend must fail closed to an explicit degraded/unknown state.
+- Historical charts are based only on stored measurements available in `air_quality_readings`; gaps are allowed and must not be filled with invented zeroes.
 
 ## Degradation rules
 
 Allowed:
 
-- Missing city from RPC -> `status: 'unknown'`, `dataQuality: 'degraded'`.
-- Missing `aqi_us` -> `status: 'unknown'`, `dataQuality: 'degraded'`.
+- Missing city from latest RPC -> `status: 'unknown'`, `dataQuality: 'degraded'`.
+- Missing `aqi_us` in latest RPC -> `status: 'unknown'`, `dataQuality: 'degraded'`.
 - Missing secondary weather fields -> show `N/D`, not invented values.
+- Missing or unavailable history RPC -> hide the chart and show a small degraded history state while preserving the latest dashboard.
 
 Prohibited:
 
@@ -114,6 +193,7 @@ Prohibited:
 - Do not represent missing data as AQI `0`.
 - Do not label a client refresh as a new upstream measurement.
 - Do not match cities by name when `city_id` is available.
+- Do not fallback historical charts to random, mocked, or zero-filled series.
 
 ## Release checklist for contract-affecting changes
 

--- a/src/components/CityHistoricalTrend.tsx
+++ b/src/components/CityHistoricalTrend.tsx
@@ -24,7 +24,7 @@ interface ChartPoint {
   aqi: number;
 }
 
-const RANGE_OPTIONS: Array<{ label: string; value: HistoryRange }> = [
+const RANGE_OPTIONS: { label: string; value: HistoryRange }[] = [
   { label: '24h', value: 24 },
   { label: '7d', value: 168 },
 ];

--- a/src/components/CityHistoricalTrend.tsx
+++ b/src/components/CityHistoricalTrend.tsx
@@ -1,0 +1,240 @@
+import { useEffect, useMemo, useState } from 'react';
+import {
+  CartesianGrid,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+import { AirQualityHistoryRow, AirQualityTrend } from '../types';
+import { fetchAirQualityHistoryForCity } from '../services/apiService';
+
+interface CityHistoricalTrendProps {
+  cityId: number;
+  cityName: string;
+}
+
+type HistoryRange = 24 | 168;
+
+interface ChartPoint {
+  timestamp: string;
+  label: string;
+  aqi: number;
+}
+
+const RANGE_OPTIONS: Array<{ label: string; value: HistoryRange }> = [
+  { label: '24h', value: 24 },
+  { label: '7d', value: 168 },
+];
+
+const MIN_POINTS_FOR_TREND = 2;
+const STABLE_DELTA = 5;
+
+function formatPointLabel(timestamp: string, range: HistoryRange) {
+  const date = new Date(timestamp);
+
+  if (Number.isNaN(date.getTime())) {
+    return 'N/D';
+  }
+
+  return date.toLocaleString('es-MX', {
+    day: range === 168 ? '2-digit' : undefined,
+    month: range === 168 ? 'short' : undefined,
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+function toChartPoint(row: AirQualityHistoryRow, range: HistoryRange): ChartPoint | null {
+  if (row.aqi_us === null) {
+    return null;
+  }
+
+  return {
+    timestamp: row.reading_timestamp,
+    label: formatPointLabel(row.reading_timestamp, range),
+    aqi: row.aqi_us,
+  };
+}
+
+function calculateTrend(points: ChartPoint[]): AirQualityTrend {
+  if (points.length < MIN_POINTS_FOR_TREND) {
+    return 'insufficient-data';
+  }
+
+  const firstPoint = points[0];
+  const lastPoint = points[points.length - 1];
+
+  if (!firstPoint || !lastPoint) {
+    return 'insufficient-data';
+  }
+
+  const delta = lastPoint.aqi - firstPoint.aqi;
+
+  if (Math.abs(delta) <= STABLE_DELTA) {
+    return 'stable';
+  }
+
+  return delta > 0 ? 'rising' : 'falling';
+}
+
+function getTrendLabel(trend: AirQualityTrend) {
+  switch (trend) {
+    case 'rising':
+      return 'Subiendo';
+    case 'falling':
+      return 'Bajando';
+    case 'stable':
+      return 'Estable';
+    default:
+      return 'Sin datos suficientes';
+  }
+}
+
+function getTrendClassName(trend: AirQualityTrend) {
+  switch (trend) {
+    case 'rising':
+      return 'border-orange-200 bg-orange-50 text-orange-700';
+    case 'falling':
+      return 'border-green-200 bg-green-50 text-green-700';
+    case 'stable':
+      return 'border-blue-200 bg-blue-50 text-blue-700';
+    default:
+      return 'border-slate-200 bg-slate-50 text-slate-600';
+  }
+}
+
+export default function CityHistoricalTrend({ cityId, cityName }: CityHistoricalTrendProps) {
+  const [range, setRange] = useState<HistoryRange>(24);
+  const [rows, setRows] = useState<AirQualityHistoryRow[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [degradedReason, setDegradedReason] = useState<string | null>(null);
+
+  useEffect(() => {
+    let isCurrent = true;
+
+    async function loadHistory() {
+      setLoading(true);
+      setDegradedReason(null);
+
+      try {
+        const historyRows = await fetchAirQualityHistoryForCity(cityId, range);
+
+        if (!isCurrent) {
+          return;
+        }
+
+        setRows(historyRows);
+      } catch {
+        if (!isCurrent) {
+          return;
+        }
+
+        setRows([]);
+        setDegradedReason('Histórico no disponible por ahora. El panel principal sigue usando datos recientes.');
+      } finally {
+        if (isCurrent) {
+          setLoading(false);
+        }
+      }
+    }
+
+    loadHistory();
+
+    return () => {
+      isCurrent = false;
+    };
+  }, [cityId, range]);
+
+  const chartPoints = useMemo(
+    () => rows.map((row) => toChartPoint(row, range)).filter((point): point is ChartPoint => point !== null),
+    [range, rows],
+  );
+
+  const trend = useMemo(() => calculateTrend(chartPoints), [chartPoints]);
+  const hasEnoughPointsForChart = chartPoints.length >= MIN_POINTS_FOR_TREND;
+
+  return (
+    <section className="rounded-2xl border border-slate-200 bg-white p-4 shadow-md dark:border-slate-700 dark:bg-slate-800 sm:p-5">
+      <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-wider text-slate-500 dark:text-slate-400">
+            Tendencia reciente
+          </p>
+          <h2 className="text-lg font-bold text-slate-900 dark:text-white">AQI histórico · {cityName}</h2>
+          <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">
+            Histórico basado en mediciones disponibles; puede haber huecos.
+          </p>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <span
+            className={`rounded-full border px-3 py-1 text-xs font-semibold ${getTrendClassName(trend)}`}
+          >
+            {getTrendLabel(trend)}
+          </span>
+          <div className="flex rounded-full bg-slate-100 p-1 dark:bg-slate-900/60">
+            {RANGE_OPTIONS.map((option) => (
+              <button
+                key={option.value}
+                type="button"
+                onClick={() => setRange(option.value)}
+                className={`rounded-full px-3 py-1 text-xs font-semibold transition ${
+                  range === option.value
+                    ? 'bg-white text-slate-900 shadow-sm dark:bg-slate-700 dark:text-white'
+                    : 'text-slate-500 hover:text-slate-900 dark:text-slate-400 dark:hover:text-white'
+                }`}
+                aria-pressed={range === option.value}
+              >
+                {option.label}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {degradedReason ? (
+        <div className="rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800" role="status">
+          {degradedReason}
+        </div>
+      ) : !hasEnoughPointsForChart ? (
+        <div className="rounded-xl border border-slate-200 bg-slate-50 px-4 py-6 text-center text-sm text-slate-600 dark:border-slate-700 dark:bg-slate-900/40 dark:text-slate-300" role="status">
+          {loading ? 'Cargando histórico disponible...' : 'Aún no hay suficientes mediciones para graficar esta ciudad.'}
+        </div>
+      ) : (
+        <div className="h-56 w-full" aria-label={`Gráfica de AQI histórico para ${cityName}`}>
+          <ResponsiveContainer width="100%" height="100%">
+            <LineChart data={chartPoints} margin={{ top: 10, right: 10, left: -16, bottom: 0 }}>
+              <CartesianGrid strokeDasharray="3 3" vertical={false} />
+              <XAxis dataKey="label" tick={{ fontSize: 11 }} minTickGap={24} />
+              <YAxis tick={{ fontSize: 11 }} width={40} domain={[0, 'dataMax + 20']} />
+              <Tooltip
+                labelFormatter={(_, payload) => {
+                  const point = payload?.[0]?.payload as ChartPoint | undefined;
+                  return point
+                    ? new Date(point.timestamp).toLocaleString('es-MX', {
+                        dateStyle: 'medium',
+                        timeStyle: 'short',
+                      })
+                    : 'Medición';
+                }}
+                formatter={(value) => [`${value} AQI`, 'AQI US']}
+              />
+              <Line
+                type="monotone"
+                dataKey="aqi"
+                stroke="currentColor"
+                strokeWidth={2}
+                dot={chartPoints.length <= 24}
+                connectNulls={false}
+                isAnimationActive={false}
+              />
+            </LineChart>
+          </ResponsiveContainer>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -8,6 +8,7 @@ import Recommendations from '../components/Recommendations';
 //import PollutantsInfo from '../components/PollutantsInfo';
 import CitySelector from '../components/CitySelector';
 import AirQualityMap from '../components/AirQualityMap';
+import CityHistoricalTrend from '../components/CityHistoricalTrend';
 //import StationMap from '../components/StationMap';
 //import AirQualityHeatmap from '../components/AirQualityHeatmap';
 //import PollutantConcentrationMap from '../components/PollutantConcentrationMap';
@@ -157,6 +158,7 @@ export default function Dashboard() {
         <div className="lg:col-span-2 flex flex-col gap-6">
           {/* Tarjeta principal de calidad del aire */}
           <AirQualityCard data={airQualityData} />
+          <CityHistoricalTrend cityId={selectedCity.city_id} cityName={selectedCity.name} />
           {/* Recomendaciones basadas en la calidad del aire */}
           <Recommendations status={airQualityData.status} />
         </div>

--- a/src/services/apiService.ts
+++ b/src/services/apiService.ts
@@ -1,5 +1,5 @@
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
-import { CityAirQualityData, HistoricalData } from '../types';
+import { AirQualityHistoryRow, CityAirQualityData } from '../types';
 
 const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL;
 const SUPABASE_ANON_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY;
@@ -93,25 +93,46 @@ export const fetchLatestMonterreyAirQuality = async (): Promise<CityAirQualityDa
   }
 };
 
-export const getFallbackHistoricalData = (): HistoricalData[] => {
-  console.warn('Usando datos históricos SIMULADOS. Implementar fetch real cuando esté disponible.');
-  const historicalData: HistoricalData[] = [];
-  const today = new Date();
-
-  for (let i = 6; i >= 0; i -= 1) {
-    const date = new Date(today);
-    date.setDate(today.getDate() - i);
-    const dateString = date.toISOString().split('T')[0];
-    const pm25 = Math.floor(Math.random() * 141) + 10;
-    const pm10 = Math.floor(Math.random() * 161) + 20;
-
-    historicalData.push({
-      date: dateString,
-      aqi: Math.max(pm25, pm10),
-      pm25,
-      pm10,
+export const fetchAirQualityHistoryForCity = async (
+  cityId: number,
+  hours: number,
+): Promise<AirQualityHistoryRow[]> => {
+  try {
+    const supabase = getSupabaseClient();
+    const { data, error } = await supabase.rpc('get_air_quality_history_for_city', {
+      p_city_id: cityId,
+      p_hours: hours,
     });
-  }
 
-  return historicalData;
+    if (error) {
+      console.warn('No se pudo consultar histórico de calidad del aire:', error);
+      throw new AirQualityServiceError(
+        'supabase_rpc_error',
+        `No se pudo consultar get_air_quality_history_for_city: ${error.message}`,
+        error,
+      );
+    }
+
+    if (!Array.isArray(data)) {
+      console.warn('Respuesta inesperada de histórico de calidad del aire:', data);
+      throw new AirQualityServiceError(
+        'supabase_unexpected_response',
+        'La respuesta de histórico de Supabase no tiene el formato esperado.',
+        data,
+      );
+    }
+
+    return data as AirQualityHistoryRow[];
+  } catch (error: unknown) {
+    if (isAirQualityServiceError(error)) {
+      throw error;
+    }
+
+    const errorMessage = error instanceof Error
+      ? error.message
+      : 'Error al obtener histórico de calidad del aire desde Supabase.';
+
+    console.warn('Detalle del error en fetchAirQualityHistoryForCity (Supabase):', error);
+    throw new AirQualityServiceError('unknown_fetch_error', errorMessage, error);
+  }
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -15,6 +15,18 @@ export interface CityAirQualityData {
   last_successful_update_at: string | null;
 }
 
+export interface AirQualityHistoryRow {
+  city_id: number;
+  city_name: string;
+  reading_timestamp: string;
+  aqi_us: number | null;
+  main_pollutant_us: string | null;
+  temperature_c: number | null;
+  humidity_percent: number | null;
+}
+
+export type AirQualityTrend = 'rising' | 'falling' | 'stable' | 'insufficient-data';
+
 export type AirQualityDataQuality = 'fresh' | 'degraded';
 
 export type CityDataAvailability = 'available' | 'missing' | 'invalid-aqi';


### PR DESCRIPTION
## Summary

Adds a conservative historical trend MVP for MtyRespira city detail/dashboard without changing the existing latest-data RPC.

- Keeps `get_latest_air_quality_per_city` as the latest dashboard source.
- Adds centralized service call for additive RPC `get_air_quality_history_for_city`.
- Adds nullable `AirQualityHistoryRow` types.
- Adds a responsive `CityHistoricalTrend` card with:
  - 24h / 7d toggle
  - AQI line chart from real historical rows only
  - trend badge: Subiendo / Bajando / Estable / Sin datos suficientes
  - honest copy: “Histórico basado en mediciones disponibles; puede haber huecos.”
- Degrades safely if the RPC is missing/fails: chart is hidden and latest dashboard still works.
- Updates `docs/shared-data-contract.md` with the additive RPC contract.

## Supabase manual SQL

Run before/around deploy to enable the history panel:

```sql
create or replace function public.get_air_quality_history_for_city(
  p_city_id bigint,
  p_hours integer default 24
)
returns table (
  city_id bigint,
  city_name text,
  reading_timestamp timestamptz,
  aqi_us smallint,
  main_pollutant_us text,
  temperature_c real,
  humidity_percent smallint
)
language sql
stable
security definer
set search_path = public
as $$
  select
    c.id as city_id,
    c.name as city_name,
    r.reading_timestamp,
    r.aqi_us,
    r.main_pollutant_us,
    r.temperature_c,
    r.humidity_percent
  from public.air_quality_readings r
  join public.cities c on c.id = r.city_id
  where c.id = p_city_id
    and c.is_active = true
    and r.reading_timestamp >= now() - make_interval(hours => greatest(1, least(coalesce(p_hours, 24), 24 * 14)))
  order by r.reading_timestamp asc;
$$;

grant execute on function public.get_air_quality_history_for_city(bigint, integer) to anon, authenticated;
```

## Rollback SQL

```sql
drop function if exists public.get_air_quality_history_for_city(bigint, integer);
```

Frontend rollback is safe because this is additive. Reverting this PR restores the previous dashboard behavior; latest RPC remains untouched.

## Validation

- CI `Web Checks`: passed.
- `Lint and typecheck`: passed.
- `Build`: passed.
- Local validation was not run because the container could not resolve `github.com` when attempting to clone the branch.

## Post-deploy validation

- Validate `https://mtyrespira.elelier.com` still loads latest dashboard data.
- Validate a known active city renders the historical trend once the RPC exists.
- Validate behavior before SQL/RPC is available: small degraded history state, no dashboard break.
- Validate no invented zero/random history appears in the chart.