### PR TITLE
feat: extend historical trend with honest variables

### DIFF
--- a/docs/shared-data-contract.md
+++ b/docs/shared-data-contract.md
@@ -40,9 +40,9 @@ supabase.rpc('get_latest_air_quality_per_city')
 
 Compatibility rule: do not rename it, remove output fields, change timestamp semantics, or change one-row-per-active-city behavior without a coordinated rollout.
 
-## Additive history RPC
+## Additive raw history RPC
 
-The frontend may consume this additive Supabase RPC for historical city trends:
+The frontend may consume this additive Supabase RPC for raw historical city trends up to 31 days:
 
 ```ts
 supabase.rpc('get_air_quality_history_for_city', {
@@ -86,16 +86,101 @@ as $$
   join public.cities c on c.id = r.city_id
   where c.id = p_city_id
     and c.is_active = true
-    and r.reading_timestamp >= now() - make_interval(hours => greatest(1, least(coalesce(p_hours, 24), 24 * 14)))
+    and r.reading_timestamp >= now() - make_interval(hours => greatest(1, least(coalesce(p_hours, 24), 24 * 31)))
   order by r.reading_timestamp asc;
 $$;
 
 grant execute on function public.get_air_quality_history_for_city(bigint, integer) to anon, authenticated;
 ```
 
+## Additive daily aggregate history RPC
+
+The frontend may consume this additive Supabase RPC for 6 month daily aggregates:
+
+```ts
+supabase.rpc('get_daily_air_quality_history_for_city', {
+  p_city_id: cityId,
+  p_days: days,
+})
+```
+
+Manual SQL to create or replace the function:
+
+```sql
+create or replace function public.get_daily_air_quality_history_for_city(
+  p_city_id bigint,
+  p_days integer default 183
+)
+returns table (
+  city_id bigint,
+  city_name text,
+  reading_date date,
+  avg_aqi_us numeric,
+  max_aqi_us smallint,
+  avg_temperature_c numeric,
+  avg_humidity_percent numeric,
+  dominant_pollutant_us text,
+  reading_count bigint
+)
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  with base as (
+    select
+      c.id as city_id,
+      c.name as city_name,
+      r.reading_timestamp::date as reading_date,
+      r.aqi_us,
+      r.main_pollutant_us,
+      r.temperature_c,
+      r.humidity_percent
+    from public.air_quality_readings r
+    join public.cities c on c.id = r.city_id
+    where c.id = p_city_id
+      and c.is_active = true
+      and r.reading_timestamp >= now() - make_interval(days => greatest(1, least(coalesce(p_days, 183), 366)))
+  ), pollutant_counts as (
+    select
+      city_id,
+      reading_date,
+      main_pollutant_us,
+      count(*) as pollutant_count,
+      row_number() over (
+        partition by city_id, reading_date
+        order by count(*) desc, main_pollutant_us asc
+      ) as pollutant_rank
+    from base
+    where main_pollutant_us is not null
+    group by city_id, reading_date, main_pollutant_us
+  )
+  select
+    b.city_id,
+    max(b.city_name) as city_name,
+    b.reading_date,
+    round(avg(b.aqi_us)::numeric, 1) as avg_aqi_us,
+    max(b.aqi_us) as max_aqi_us,
+    round(avg(b.temperature_c)::numeric, 1) as avg_temperature_c,
+    round(avg(b.humidity_percent)::numeric, 1) as avg_humidity_percent,
+    max(pc.main_pollutant_us) filter (where pc.pollutant_rank = 1) as dominant_pollutant_us,
+    count(*) as reading_count
+  from base b
+  left join pollutant_counts pc
+    on pc.city_id = b.city_id
+   and pc.reading_date = b.reading_date
+   and pc.pollutant_rank = 1
+  group by b.city_id, b.reading_date
+  order by b.reading_date asc;
+$$;
+
+grant execute on function public.get_daily_air_quality_history_for_city(bigint, integer) to anon, authenticated;
+```
+
 Rollback SQL:
 
 ```sql
+drop function if exists public.get_daily_air_quality_history_for_city(bigint, integer);
 drop function if exists public.get_air_quality_history_for_city(bigint, integer);
 ```
 
@@ -124,9 +209,9 @@ The frontend expects an array compatible with this shape:
 ]
 ```
 
-## Canonical history RPC payload
+## Canonical raw history RPC payload
 
-The history RPC returns rows ordered by `reading_timestamp` ascending:
+The raw history RPC returns rows ordered by `reading_timestamp` ascending:
 
 ```jsonc
 [
@@ -142,6 +227,26 @@ The history RPC returns rows ordered by `reading_timestamp` ascending:
 ]
 ```
 
+## Canonical daily history RPC payload
+
+The daily history RPC returns rows ordered by `reading_date` ascending:
+
+```jsonc
+[
+  {
+    "city_id": 9,
+    "city_name": "Monterrey",
+    "reading_date": "2026-01-01",
+    "avg_aqi_us": 75.4,
+    "max_aqi_us": 92,
+    "avg_temperature_c": 23.1,
+    "avg_humidity_percent": 45.2,
+    "dominant_pollutant_us": "p2",
+    "reading_count": 24
+  }
+]
+```
+
 ## Field contract
 
 | Field | TypeScript expectation | Nullability rule | Notes |
@@ -152,10 +257,16 @@ The history RPC returns rows ordered by `reading_timestamp` ascending:
 | `latitude` | `number \| null` | nullable | Frontend falls back to static city coordinates if null. |
 | `longitude` | `number \| null` | nullable | Frontend falls back to static city coordinates if null. |
 | `reading_timestamp` | `string` | required | Source measurement time. Treat as UTC. |
-| `aqi_us` | `number \| null` | nullable | If null, frontend must degrade to `unknown`. History chart excludes null AQI rows. |
-| `main_pollutant_us` | `string \| null` | nullable | UI shows `N/D` if missing. |
+| `reading_date` | `string` | required for daily aggregate RPC | Daily bucket date derived from `reading_timestamp`. |
+| `aqi_us` | `number \| null` | nullable | If null, frontend must degrade to `unknown`. History chart excludes null metric rows. |
+| `avg_aqi_us` | `number \| null` | nullable | Daily aggregate average. |
+| `max_aqi_us` | `number \| null` | nullable | Daily aggregate max. |
+| `main_pollutant_us` | `string \| null` | nullable | Dominant pollutant marker, not pollutant concentration. |
+| `dominant_pollutant_us` | `string \| null` | nullable | Daily dominant pollutant marker, not pollutant concentration. |
 | `temperature_c` | `number \| null` | nullable | UI shows `N/D` if missing. |
+| `avg_temperature_c` | `number \| null` | nullable | Daily aggregate average. |
 | `humidity_percent` | `number \| null` | nullable | UI shows `N/D` if missing. |
+| `avg_humidity_percent` | `number \| null` | nullable | Daily aggregate average. |
 | `wind_speed_ms` | `number \| null` | nullable | UI shows `N/D` if missing. |
 | `wind_direction_deg` | `number \| null` | nullable | UI hides icon rotation if missing. |
 | `weather_icon` | `string \| null` | nullable | UI hides weather icon if missing. |
@@ -177,6 +288,22 @@ Rules:
 - The UI must not imply stronger freshness than the hourly producer cadence.
 - If data is missing, stale, nullable in critical fields, or contract-invalid, the frontend must fail closed to an explicit degraded/unknown state.
 - Historical charts are based only on stored measurements available in `air_quality_readings`; gaps are allowed and must not be filled with invented zeroes.
+- 24h, 7d, and 30d use raw readings by `reading_timestamp`.
+- 6m uses daily aggregates to avoid heavy mobile chart rendering.
+
+## Pollutant data limitation
+
+The current AirVisual integration exposes and stores AQI and dominant pollutant keys from `current.pollution` (`aqius`, `mainus`, `aqicn`, `maincn`, `ts`). It does not provide confirmed historical concentration series for PM2.5, PM10, O3, NO2, SO2, or CO in the current contract.
+
+Allowed:
+
+- Show `main_pollutant_us` or `dominant_pollutant_us` as dominant pollutant metadata.
+- Show distribution/frequency of dominant pollutant values.
+
+Prohibited:
+
+- Do not graph PM2.5, PM10, O3, NO2, SO2, or CO as concentration series unless new columns or a confirmed provider contract exist.
+- Do not infer pollutant concentrations from AQI or dominant pollutant markers.
 
 ## Degradation rules
 

--- a/src/components/CityHistoricalTrend.tsx
+++ b/src/components/CityHistoricalTrend.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import {
+  Bar,
+  BarChart,
   CartesianGrid,
   Line,
   LineChart,
@@ -8,29 +10,103 @@ import {
   XAxis,
   YAxis,
 } from 'recharts';
-import { AirQualityHistoryRow, AirQualityTrend } from '../types';
-import { fetchAirQualityHistoryForCity } from '../services/apiService';
+import {
+  AirQualityDailyHistoryRow,
+  AirQualityHistoryMetric,
+  AirQualityHistoryRow,
+  AirQualityTrend,
+} from '../types';
+import {
+  fetchAirQualityHistoryForCity,
+  fetchDailyAirQualityHistoryForCity,
+} from '../services/apiService';
 
 interface CityHistoricalTrendProps {
   cityId: number;
   cityName: string;
 }
 
-type HistoryRange = 24 | 168;
+type HistoryRange = '24h' | '7d' | '30d' | '6m';
+
+type HistoryRow = AirQualityHistoryRow | AirQualityDailyHistoryRow;
 
 interface ChartPoint {
   timestamp: string;
   label: string;
-  aqi: number;
+  value: number;
+}
+
+interface PollutantSummaryItem {
+  pollutant: string;
+  count: number;
+  percentage: number;
 }
 
 const RANGE_OPTIONS: { label: string; value: HistoryRange }[] = [
-  { label: '24h', value: 24 },
-  { label: '7d', value: 168 },
+  { label: '24h', value: '24h' },
+  { label: '7d', value: '7d' },
+  { label: '30d', value: '30d' },
+  { label: '6m', value: '6m' },
 ];
 
+const METRIC_OPTIONS: { label: string; value: AirQualityHistoryMetric; suffix: string }[] = [
+  { label: 'AQI US', value: 'aqi_us', suffix: ' AQI' },
+  { label: 'Temperatura', value: 'temperature_c', suffix: '°C' },
+  { label: 'Humedad', value: 'humidity_percent', suffix: '%' },
+];
+
+const RANGE_TO_HOURS: Record<Exclude<HistoryRange, '6m'>, number> = {
+  '24h': 24,
+  '7d': 168,
+  '30d': 24 * 31,
+};
+
+const SIX_MONTH_DAYS = 183;
 const MIN_POINTS_FOR_TREND = 2;
-const STABLE_DELTA = 5;
+const STABLE_DELTA_BY_METRIC: Record<AirQualityHistoryMetric, number> = {
+  aqi_us: 5,
+  temperature_c: 1,
+  humidity_percent: 3,
+};
+
+function isDailyRow(row: HistoryRow): row is AirQualityDailyHistoryRow {
+  return 'reading_date' in row;
+}
+
+function getMetricConfig(metric: AirQualityHistoryMetric) {
+  const config = METRIC_OPTIONS.find((option) => option.value === metric);
+  return config ?? METRIC_OPTIONS[0];
+}
+
+function getTimestamp(row: HistoryRow) {
+  return isDailyRow(row) ? row.reading_date : row.reading_timestamp;
+}
+
+function getPollutant(row: HistoryRow) {
+  return isDailyRow(row) ? row.dominant_pollutant_us : row.main_pollutant_us;
+}
+
+function getMetricValue(row: HistoryRow, metric: AirQualityHistoryMetric): number | null {
+  if (isDailyRow(row)) {
+    switch (metric) {
+      case 'temperature_c':
+        return row.avg_temperature_c;
+      case 'humidity_percent':
+        return row.avg_humidity_percent;
+      default:
+        return row.avg_aqi_us;
+    }
+  }
+
+  switch (metric) {
+    case 'temperature_c':
+      return row.temperature_c;
+    case 'humidity_percent':
+      return row.humidity_percent;
+    default:
+      return row.aqi_us;
+  }
+}
 
 function formatPointLabel(timestamp: string, range: HistoryRange) {
   const date = new Date(timestamp);
@@ -39,27 +115,39 @@ function formatPointLabel(timestamp: string, range: HistoryRange) {
     return 'N/D';
   }
 
+  if (range === '6m') {
+    return date.toLocaleDateString('es-MX', { month: 'short', day: '2-digit' });
+  }
+
   return date.toLocaleString('es-MX', {
-    day: range === 168 ? '2-digit' : undefined,
-    month: range === 168 ? 'short' : undefined,
+    day: range === '24h' ? undefined : '2-digit',
+    month: range === '24h' ? undefined : 'short',
     hour: '2-digit',
     minute: '2-digit',
   });
 }
 
-function toChartPoint(row: AirQualityHistoryRow, range: HistoryRange): ChartPoint | null {
-  if (row.aqi_us === null) {
+function toChartPoint(
+  row: HistoryRow,
+  range: HistoryRange,
+  metric: AirQualityHistoryMetric,
+): ChartPoint | null {
+  const metricValue = getMetricValue(row, metric);
+
+  if (metricValue === null) {
     return null;
   }
 
+  const timestamp = getTimestamp(row);
+
   return {
-    timestamp: row.reading_timestamp,
-    label: formatPointLabel(row.reading_timestamp, range),
-    aqi: row.aqi_us,
+    timestamp,
+    label: formatPointLabel(timestamp, range),
+    value: Number(metricValue.toFixed(1)),
   };
 }
 
-function calculateTrend(points: ChartPoint[]): AirQualityTrend {
+function calculateTrend(points: ChartPoint[], metric: AirQualityHistoryMetric): AirQualityTrend {
   if (points.length < MIN_POINTS_FOR_TREND) {
     return 'insufficient-data';
   }
@@ -71,9 +159,9 @@ function calculateTrend(points: ChartPoint[]): AirQualityTrend {
     return 'insufficient-data';
   }
 
-  const delta = lastPoint.aqi - firstPoint.aqi;
+  const delta = lastPoint.value - firstPoint.value;
 
-  if (Math.abs(delta) <= STABLE_DELTA) {
+  if (Math.abs(delta) <= STABLE_DELTA_BY_METRIC[metric]) {
     return 'stable';
   }
 
@@ -106,9 +194,45 @@ function getTrendClassName(trend: AirQualityTrend) {
   }
 }
 
+function getMetricCopy(metric: AirQualityHistoryMetric, range: HistoryRange) {
+  if (range === '6m') {
+    return metric === 'aqi_us' ? 'promedio diario de AQI' : 'promedio diario';
+  }
+
+  return 'mediciones disponibles';
+}
+
+function buildPollutantSummary(rows: HistoryRow[]): PollutantSummaryItem[] {
+  const counts = rows.reduce<Map<string, number>>((summary, row) => {
+    const pollutant = getPollutant(row);
+
+    if (!pollutant) {
+      return summary;
+    }
+
+    summary.set(pollutant, (summary.get(pollutant) ?? 0) + 1);
+    return summary;
+  }, new Map<string, number>());
+
+  const total = Array.from(counts.values()).reduce((sum, count) => sum + count, 0);
+
+  if (total === 0) {
+    return [];
+  }
+
+  return Array.from(counts.entries())
+    .map(([pollutant, count]) => ({
+      pollutant,
+      count,
+      percentage: Math.round((count / total) * 100),
+    }))
+    .sort((left, right) => right.count - left.count);
+}
+
 export default function CityHistoricalTrend({ cityId, cityName }: CityHistoricalTrendProps) {
-  const [range, setRange] = useState<HistoryRange>(24);
-  const [rows, setRows] = useState<AirQualityHistoryRow[]>([]);
+  const [range, setRange] = useState<HistoryRange>('24h');
+  const [metric, setMetric] = useState<AirQualityHistoryMetric>('aqi_us');
+  const [rows, setRows] = useState<HistoryRow[]>([]);
   const [loading, setLoading] = useState(false);
   const [degradedReason, setDegradedReason] = useState<string | null>(null);
 
@@ -120,7 +244,9 @@ export default function CityHistoricalTrend({ cityId, cityName }: CityHistorical
       setDegradedReason(null);
 
       try {
-        const historyRows = await fetchAirQualityHistoryForCity(cityId, range);
+        const historyRows = range === '6m'
+          ? await fetchDailyAirQualityHistoryForCity(cityId, SIX_MONTH_DAYS)
+          : await fetchAirQualityHistoryForCity(cityId, RANGE_TO_HOURS[range]);
 
         if (!isCurrent) {
           return;
@@ -148,34 +274,45 @@ export default function CityHistoricalTrend({ cityId, cityName }: CityHistorical
     };
   }, [cityId, range]);
 
+  const metricConfig = getMetricConfig(metric);
+
   const chartPoints = useMemo(
-    () => rows.map((row) => toChartPoint(row, range)).filter((point): point is ChartPoint => point !== null),
-    [range, rows],
+    () => rows
+      .map((row) => toChartPoint(row, range, metric))
+      .filter((point): point is ChartPoint => point !== null),
+    [metric, range, rows],
   );
 
-  const trend = useMemo(() => calculateTrend(chartPoints), [chartPoints]);
+  const trend = useMemo(() => calculateTrend(chartPoints, metric), [chartPoints, metric]);
+  const pollutantSummary = useMemo(() => buildPollutantSummary(rows), [rows]);
+  const dominantPollutant = pollutantSummary[0];
   const hasEnoughPointsForChart = chartPoints.length >= MIN_POINTS_FOR_TREND;
 
   return (
     <section className="rounded-2xl border border-slate-200 bg-white p-4 shadow-md dark:border-slate-700 dark:bg-slate-800 sm:p-5">
-      <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+      <div className="mb-4 flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
         <div>
           <p className="text-xs font-semibold uppercase tracking-wider text-slate-500 dark:text-slate-400">
             Tendencia reciente
           </p>
-          <h2 className="text-lg font-bold text-slate-900 dark:text-white">AQI histórico · {cityName}</h2>
+          <h2 className="text-lg font-bold text-slate-900 dark:text-white">
+            Histórico · {cityName}
+          </h2>
           <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">
             Histórico basado en mediciones disponibles; puede haber huecos.
           </p>
+          <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">
+            AirVisual expone AQI y contaminante dominante; no concentraciones históricas por partícula en esta integración.
+          </p>
         </div>
 
-        <div className="flex items-center gap-2">
+        <div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center lg:justify-end">
           <span
-            className={`rounded-full border px-3 py-1 text-xs font-semibold ${getTrendClassName(trend)}`}
+            className={`w-fit rounded-full border px-3 py-1 text-xs font-semibold ${getTrendClassName(trend)}`}
           >
             {getTrendLabel(trend)}
           </span>
-          <div className="flex rounded-full bg-slate-100 p-1 dark:bg-slate-900/60">
+          <div className="flex w-fit rounded-full bg-slate-100 p-1 dark:bg-slate-900/60">
             {RANGE_OPTIONS.map((option) => (
               <button
                 key={option.value}
@@ -195,39 +332,57 @@ export default function CityHistoricalTrend({ cityId, cityName }: CityHistorical
         </div>
       </div>
 
+      <div className="mb-4 flex flex-wrap gap-2">
+        {METRIC_OPTIONS.map((option) => (
+          <button
+            key={option.value}
+            type="button"
+            onClick={() => setMetric(option.value)}
+            className={`rounded-full border px-3 py-1 text-xs font-semibold transition ${
+              metric === option.value
+                ? 'border-slate-900 bg-slate-900 text-white dark:border-white dark:bg-white dark:text-slate-900'
+                : 'border-slate-200 text-slate-600 hover:border-slate-400 dark:border-slate-700 dark:text-slate-300'
+            }`}
+            aria-pressed={metric === option.value}
+          >
+            {option.label}
+          </button>
+        ))}
+      </div>
+
       {degradedReason ? (
         <div className="rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800" role="status">
           {degradedReason}
         </div>
       ) : !hasEnoughPointsForChart ? (
         <div className="rounded-xl border border-slate-200 bg-slate-50 px-4 py-6 text-center text-sm text-slate-600 dark:border-slate-700 dark:bg-slate-900/40 dark:text-slate-300" role="status">
-          {loading ? 'Cargando histórico disponible...' : 'Aún no hay suficientes mediciones para graficar esta ciudad.'}
+          {loading ? 'Cargando histórico disponible...' : 'Aún no hay suficientes mediciones para graficar esta métrica.'}
         </div>
       ) : (
-        <div className="h-56 w-full" aria-label={`Gráfica de AQI histórico para ${cityName}`}>
+        <div className="h-56 w-full" aria-label={`Gráfica histórica de ${metricConfig.label} para ${cityName}`}>
           <ResponsiveContainer width="100%" height="100%">
             <LineChart data={chartPoints} margin={{ top: 10, right: 10, left: -16, bottom: 0 }}>
               <CartesianGrid strokeDasharray="3 3" vertical={false} />
               <XAxis dataKey="label" tick={{ fontSize: 11 }} minTickGap={24} />
-              <YAxis tick={{ fontSize: 11 }} width={40} domain={[0, 'dataMax + 20']} />
+              <YAxis tick={{ fontSize: 11 }} width={40} domain={['auto', 'auto']} />
               <Tooltip
                 labelFormatter={(_, payload) => {
                   const point = payload?.[0]?.payload as ChartPoint | undefined;
                   return point
                     ? new Date(point.timestamp).toLocaleString('es-MX', {
                         dateStyle: 'medium',
-                        timeStyle: 'short',
+                        timeStyle: range === '6m' ? undefined : 'short',
                       })
                     : 'Medición';
                 }}
-                formatter={(value) => [`${value} AQI`, 'AQI US']}
+                formatter={(value) => [`${value}${metricConfig.suffix}`, metricConfig.label]}
               />
               <Line
                 type="monotone"
-                dataKey="aqi"
+                dataKey="value"
                 stroke="currentColor"
                 strokeWidth={2}
-                dot={chartPoints.length <= 24}
+                dot={range === '24h'}
                 connectNulls={false}
                 isAnimationActive={false}
               />
@@ -235,6 +390,37 @@ export default function CityHistoricalTrend({ cityId, cityName }: CityHistorical
           </ResponsiveContainer>
         </div>
       )}
+
+      <div className="mt-4 rounded-xl border border-slate-200 bg-slate-50 p-4 dark:border-slate-700 dark:bg-slate-900/40">
+        <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-wider text-slate-500 dark:text-slate-400">
+              Contaminante dominante
+            </p>
+            <p className="text-sm font-medium text-slate-800 dark:text-slate-100">
+              {dominantPollutant
+                ? `${dominantPollutant.pollutant} fue dominante en ${dominantPollutant.percentage}% de las mediciones.`
+                : 'Sin datos suficientes de contaminante dominante.'}
+            </p>
+          </div>
+          <p className="text-xs text-slate-500 dark:text-slate-400">
+            Basado en {getMetricCopy(metric, range)}.
+          </p>
+        </div>
+
+        {pollutantSummary.length > 0 && (
+          <div className="mt-3 h-28 w-full">
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart data={pollutantSummary.slice(0, 5)} margin={{ top: 8, right: 8, left: -18, bottom: 0 }}>
+                <XAxis dataKey="pollutant" tick={{ fontSize: 11 }} />
+                <YAxis tick={{ fontSize: 11 }} width={36} allowDecimals={false} />
+                <Tooltip formatter={(value) => [`${value} mediciones`, 'Frecuencia']} />
+                <Bar dataKey="count" fill="currentColor" radius={[6, 6, 0, 0]} />
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
+        )}
+      </div>
     </section>
   );
 }

--- a/src/services/apiService.ts
+++ b/src/services/apiService.ts
@@ -1,5 +1,5 @@
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
-import { AirQualityHistoryRow, CityAirQualityData } from '../types';
+import { AirQualityDailyHistoryRow, AirQualityHistoryRow, CityAirQualityData } from '../types';
 
 const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL;
 const SUPABASE_ANON_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY;
@@ -43,6 +43,17 @@ const getSupabaseClient = () => {
   return supabaseClient;
 };
 
+function assertRpcArray(data: unknown, context: string) {
+  if (!Array.isArray(data)) {
+    console.warn(`Respuesta inesperada de ${context}:`, data);
+    throw new AirQualityServiceError(
+      'supabase_unexpected_response',
+      `La respuesta de ${context} no tiene el formato esperado.`,
+      data,
+    );
+  }
+}
+
 export const MONTERREY_LOCATIONS_WITH_COORDS = [
   { city_id: 9, name: 'Monterrey', latitude: 25.67507, longitude: -100.31847 },
   { city_id: 12, name: 'San Pedro Garza Garcia', latitude: 25.65716, longitude: -100.40268 },
@@ -69,14 +80,7 @@ export const fetchLatestMonterreyAirQuality = async (): Promise<CityAirQualityDa
       );
     }
 
-    if (!Array.isArray(data)) {
-      console.error('Respuesta inesperada de la función de Supabase:', data);
-      throw new AirQualityServiceError(
-        'supabase_unexpected_response',
-        'La respuesta de Supabase no tiene el formato esperado (no es un array).',
-        data,
-      );
-    }
+    assertRpcArray(data, 'la RPC de calidad del aire');
 
     return data as CityAirQualityData[];
   } catch (error: unknown) {
@@ -113,14 +117,7 @@ export const fetchAirQualityHistoryForCity = async (
       );
     }
 
-    if (!Array.isArray(data)) {
-      console.warn('Respuesta inesperada de histórico de calidad del aire:', data);
-      throw new AirQualityServiceError(
-        'supabase_unexpected_response',
-        'La respuesta de histórico de Supabase no tiene el formato esperado.',
-        data,
-      );
-    }
+    assertRpcArray(data, 'histórico de calidad del aire');
 
     return data as AirQualityHistoryRow[];
   } catch (error: unknown) {
@@ -133,6 +130,43 @@ export const fetchAirQualityHistoryForCity = async (
       : 'Error al obtener histórico de calidad del aire desde Supabase.';
 
     console.warn('Detalle del error en fetchAirQualityHistoryForCity (Supabase):', error);
+    throw new AirQualityServiceError('unknown_fetch_error', errorMessage, error);
+  }
+};
+
+export const fetchDailyAirQualityHistoryForCity = async (
+  cityId: number,
+  days: number,
+): Promise<AirQualityDailyHistoryRow[]> => {
+  try {
+    const supabase = getSupabaseClient();
+    const { data, error } = await supabase.rpc('get_daily_air_quality_history_for_city', {
+      p_city_id: cityId,
+      p_days: days,
+    });
+
+    if (error) {
+      console.warn('No se pudo consultar histórico diario de calidad del aire:', error);
+      throw new AirQualityServiceError(
+        'supabase_rpc_error',
+        `No se pudo consultar get_daily_air_quality_history_for_city: ${error.message}`,
+        error,
+      );
+    }
+
+    assertRpcArray(data, 'histórico diario de calidad del aire');
+
+    return data as AirQualityDailyHistoryRow[];
+  } catch (error: unknown) {
+    if (isAirQualityServiceError(error)) {
+      throw error;
+    }
+
+    const errorMessage = error instanceof Error
+      ? error.message
+      : 'Error al obtener histórico diario de calidad del aire desde Supabase.';
+
+    console.warn('Detalle del error en fetchDailyAirQualityHistoryForCity (Supabase):', error);
     throw new AirQualityServiceError('unknown_fetch_error', errorMessage, error);
   }
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -25,7 +25,21 @@ export interface AirQualityHistoryRow {
   humidity_percent: number | null;
 }
 
+export interface AirQualityDailyHistoryRow {
+  city_id: number;
+  city_name: string;
+  reading_date: string;
+  avg_aqi_us: number | null;
+  max_aqi_us: number | null;
+  avg_temperature_c: number | null;
+  avg_humidity_percent: number | null;
+  dominant_pollutant_us: string | null;
+  reading_count: number;
+}
+
 export type AirQualityTrend = 'rising' | 'falling' | 'stable' | 'insufficient-data';
+
+export type AirQualityHistoryMetric = 'aqi_us' | 'temperature_c' | 'humidity_percent';
 
 export type AirQualityDataQuality = 'fresh' | 'degraded';
 


### PR DESCRIPTION
## Summary

Implements Story — MtyRespira historical trend v2: 30d/6m + honest available variables.

- Adds historical range toggle: `24h / 7d / 30d / 6m`.
- Keeps raw readings for `24h`, `7d`, and `30d`.
- Uses daily aggregate RPC for `6m` to avoid heavy mobile rendering.
- Adds metric selector:
  - AQI US
  - Temperatura
  - Humedad
- Adds dominant pollutant summary from `main_pollutant_us` / `dominant_pollutant_us`.
- Adds honest limitation copy:
  - “AirVisual expone AQI y contaminante dominante; no concentraciones históricas por partícula en esta integración.”
- Does not graph PM2.5/PM10/O3/NO2/SO2/CO as concentration series.
- Updates `docs/shared-data-contract.md` with additive raw and daily aggregate history RPCs.

## Supabase manual SQL

Run both blocks.

### 1) Raw history up to 31 days

```sql
create or replace function public.get_air_quality_history_for_city(
  p_city_id bigint,
  p_hours integer default 24
)
returns table (
  city_id bigint,
  city_name text,
  reading_timestamp timestamptz,
  aqi_us smallint,
  main_pollutant_us text,
  temperature_c real,
  humidity_percent smallint
)
language sql
stable
security definer
set search_path = public
as $$
  select
    c.id as city_id,
    c.name as city_name,
    r.reading_timestamp,
    r.aqi_us,
    r.main_pollutant_us,
    r.temperature_c,
    r.humidity_percent
  from public.air_quality_readings r
  join public.cities c on c.id = r.city_id
  where c.id = p_city_id
    and c.is_active = true
    and r.reading_timestamp >= now() - make_interval(hours => greatest(1, least(coalesce(p_hours, 24), 24 * 31)))
  order by r.reading_timestamp asc;
$$;

grant execute on function public.get_air_quality_history_for_city(bigint, integer) to anon, authenticated;
```

### 2) Daily aggregate history for 6m

```sql
create or replace function public.get_daily_air_quality_history_for_city(
  p_city_id bigint,
  p_days integer default 183
)
returns table (
  city_id bigint,
  city_name text,
  reading_date date,
  avg_aqi_us numeric,
  max_aqi_us smallint,
  avg_temperature_c numeric,
  avg_humidity_percent numeric,
  dominant_pollutant_us text,
  reading_count bigint
)
language sql
stable
security definer
set search_path = public
as $$
  with base as (
    select
      c.id as city_id,
      c.name as city_name,
      r.reading_timestamp::date as reading_date,
      r.aqi_us,
      r.main_pollutant_us,
      r.temperature_c,
      r.humidity_percent
    from public.air_quality_readings r
    join public.cities c on c.id = r.city_id
    where c.id = p_city_id
      and c.is_active = true
      and r.reading_timestamp >= now() - make_interval(days => greatest(1, least(coalesce(p_days, 183), 366)))
  ), pollutant_counts as (
    select
      city_id,
      reading_date,
      main_pollutant_us,
      count(*) as pollutant_count,
      row_number() over (
        partition by city_id, reading_date
        order by count(*) desc, main_pollutant_us asc
      ) as pollutant_rank
    from base
    where main_pollutant_us is not null
    group by city_id, reading_date, main_pollutant_us
  )
  select
    b.city_id,
    max(b.city_name) as city_name,
    b.reading_date,
    round(avg(b.aqi_us)::numeric, 1) as avg_aqi_us,
    max(b.aqi_us) as max_aqi_us,
    round(avg(b.temperature_c)::numeric, 1) as avg_temperature_c,
    round(avg(b.humidity_percent)::numeric, 1) as avg_humidity_percent,
    max(pc.main_pollutant_us) filter (where pc.pollutant_rank = 1) as dominant_pollutant_us,
    count(*) as reading_count
  from base b
  left join pollutant_counts pc
    on pc.city_id = b.city_id
   and pc.reading_date = b.reading_date
   and pc.pollutant_rank = 1
  group by b.city_id, b.reading_date
  order by b.reading_date asc;
$$;

grant execute on function public.get_daily_air_quality_history_for_city(bigint, integer) to anon, authenticated;
```

## Rollback SQL

```sql
drop function if exists public.get_daily_air_quality_history_for_city(bigint, integer);
drop function if exists public.get_air_quality_history_for_city(bigint, integer);
```

## Validation

- CI `Web Checks`: passed.
- `Lint and typecheck`: passed.
- `Build`: passed.

## Post-deploy validation

- Validate `https://mtyrespira.elelier.com` still loads latest dashboard data from `get_latest_air_quality_per_city`.
- Validate 24h/7d/30d render raw measurements.
- Validate 6m renders daily aggregates.
- Validate metric selector AQI/Temperatura/Humedad.
- Validate dominant pollutant summary appears only as dominant marker, not concentration series.
- Validate no PM2.5/PM10/O3/NO2/SO2/CO concentration series are shown.