### PR TITLE
feat: capture out-of-coverage demand signals

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,8 @@ VITE_SUPABASE_URL=
 VITE_SUPABASE_ANON_KEY=
 
 # Elelier Core DB public RPC submit_signal for anonymous demand signals.
-# Do not use service_role in frontend.
+# Use a Supabase publishable key. Do not use service_role in frontend.
 VITE_CORE_DB_SUPABASE_URL=https://adntcjusglrkeolucbyk.supabase.co
-VITE_CORE_DB_SUPABASE_ANON_KEY=
+VITE_CORE_DB_SUPABASE_PUBLISHABLE_KEY=
+VITE_CORE_SPACE_KEY=mtyrespira
+VITE_CORE_APP_KEY=mtyrespira-web

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+VITE_SUPABASE_URL=
+VITE_SUPABASE_ANON_KEY=
+
+# Elelier Core DB public RPC submit_signal for anonymous demand signals.
+# Do not use service_role in frontend.
+VITE_CORE_DB_SUPABASE_URL=https://adntcjusglrkeolucbyk.supabase.co
+VITE_CORE_DB_SUPABASE_ANON_KEY=

--- a/src/components/CitySelector.tsx
+++ b/src/components/CitySelector.tsx
@@ -1,9 +1,11 @@
 import { useState, useRef, useEffect, useMemo, useCallback } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { IoChevronDownOutline } from 'react-icons/io5';
+import { IoChevronDownOutline, IoLocateOutline } from 'react-icons/io5';
 import { MONTERREY_LOCATIONS_WITH_COORDS } from '../services/apiService';
+import { submitOutOfCoverageDemandSignal } from '../services/coreSignalService';
 import { CitySelectorOption } from '../types';
 import PinIcon from '../assets/icons/pin.png';
+import { findNearestSupportedCity, isOutOfCoverage } from '../utils/coverageUtils';
 
 type CityOption = (typeof MONTERREY_LOCATIONS_WITH_COORDS)[number];
 
@@ -13,6 +15,10 @@ interface CitySelectorProps {
   cityOptions?: CitySelectorOption[];
   className?: string;
 }
+
+const OUT_OF_COVERAGE_MESSAGE = 'Estás fuera del área cubierta por MtyRespira. Puedes elegir un municipio manualmente.';
+const GEOLOCATION_SUCCESS_MESSAGE_MS = 3500;
+const GEOLOCATION_WARNING_MESSAGE_MS = 6000;
 
 const CitySelector = ({
   onCityChange,
@@ -29,8 +35,21 @@ const CitySelector = ({
 
   const [selectedCityId, setSelectedCityId] = useState<number | null>(defaultCityId);
   const [isOpen, setIsOpen] = useState(false);
+  const [isLocating, setIsLocating] = useState(false);
+  const [locationMessage, setLocationMessage] = useState<string | null>(null);
+  const [locationMessageTone, setLocationMessageTone] = useState<'success' | 'warning'>('success');
   const dropdownRef = useRef<HTMLDivElement>(null);
   const cityRefs = useRef(new Map<number, HTMLDivElement>());
+
+  const showLocationMessage = useCallback((message: string, tone: 'success' | 'warning') => {
+    setLocationMessage(message);
+    setLocationMessageTone(tone);
+
+    window.setTimeout(
+      () => setLocationMessage(null),
+      tone === 'warning' ? GEOLOCATION_WARNING_MESSAGE_MS : GEOLOCATION_SUCCESS_MESSAGE_MS,
+    );
+  }, []);
 
   useEffect(() => {
     if (controlledSelectedCity) {
@@ -88,6 +107,64 @@ const CitySelector = ({
     setIsOpen(false);
   };
 
+  const handleUseLocation = () => {
+    if (!navigator.geolocation) {
+      showLocationMessage('Tu navegador no permite usar ubicación automática.', 'warning');
+      return;
+    }
+
+    setIsLocating(true);
+
+    navigator.geolocation.getCurrentPosition(
+      (position) => {
+        const nearest = findNearestSupportedCity(
+          position.coords.latitude,
+          position.coords.longitude,
+          locations,
+        );
+
+        if (!nearest) {
+          showLocationMessage('No hay municipios configurados para comparar tu ubicación.', 'warning');
+          setIsLocating(false);
+          return;
+        }
+
+        if (isOutOfCoverage(nearest.distanceKm)) {
+          showLocationMessage(OUT_OF_COVERAGE_MESSAGE, 'warning');
+          void submitOutOfCoverageDemandSignal({
+            nearestSupportedCity: nearest.city.name,
+            roundedDistanceKm: nearest.roundedDistanceKm,
+            distanceBucket: nearest.distanceBucket,
+          }).catch((error: unknown) => {
+            console.warn('No se pudo registrar señal anónima fuera de cobertura:', error);
+          });
+          setIsLocating(false);
+          return;
+        }
+
+        const matchingCity = resolvedCityOptions.find((city) => city.city_id === nearest.city.city_id);
+
+        if (!matchingCity || matchingCity.availability !== 'available') {
+          showLocationMessage(
+            `${nearest.city.name} fue detectado, pero no tiene lectura reciente disponible.`,
+            'warning',
+          );
+          setIsLocating(false);
+          return;
+        }
+
+        handleCityChange(matchingCity);
+        showLocationMessage(`Ubicación detectada: ${matchingCity.name}`, 'success');
+        setIsLocating(false);
+      },
+      () => {
+        showLocationMessage('No pudimos detectar tu ubicación. Puedes elegir un municipio manualmente.', 'warning');
+        setIsLocating(false);
+      },
+      { enableHighAccuracy: false, timeout: 10000, maximumAge: 5 * 60 * 1000 },
+    );
+  };
+
   const renderCityOption = (city: CitySelectorOption) => {
     const isSelected = selectedCity?.city_id === city.city_id;
     const isDisabled = city.availability !== 'available';
@@ -134,34 +211,66 @@ const CitySelector = ({
 
   return (
     <div className={`relative z-20 ${className}`} ref={dropdownRef}>
-      <motion.div
-        whileTap={{ scale: 0.98 }}
-        className="flex cursor-pointer items-center justify-between rounded-lg border border-gray-200 bg-white p-3 shadow-md dark:border-gray-700 dark:bg-slate-800"
-        onClick={() => setIsOpen(!isOpen)}
-        role="combobox"
-        aria-expanded={isOpen}
-        aria-haspopup="listbox"
-        aria-label="Seleccionar ciudad"
-      >
-        <div className="flex items-center">
-          <div className="mr-3 flex-shrink-0 rounded-full bg-purple-100 p-2 dark:bg-purple-900/30">
-            <img src={PinIcon} alt="Pin" className="h-5 w-5 text-purple-600 dark:text-purple-400" />
+      <div className="flex items-stretch gap-2">
+        <motion.div
+          whileTap={{ scale: 0.98 }}
+          className="flex min-w-0 flex-1 cursor-pointer items-center justify-between rounded-lg border border-gray-200 bg-white p-3 shadow-md dark:border-gray-700 dark:bg-slate-800"
+          onClick={() => setIsOpen(!isOpen)}
+          role="combobox"
+          aria-expanded={isOpen}
+          aria-haspopup="listbox"
+          aria-label="Seleccionar ciudad"
+        >
+          <div className="flex min-w-0 items-center">
+            <div className="mr-2 flex-shrink-0 rounded-full bg-purple-100 p-2 dark:bg-purple-900/30 sm:mr-3">
+              <img src={PinIcon} alt="Pin" className="h-5 w-5 text-purple-600 dark:text-purple-400" />
+            </div>
+            <div className="min-w-0">
+              <p className="truncate text-sm font-medium text-gray-900 dark:text-white">
+                {selectedCity?.name ?? 'Selecciona una ciudad'}
+              </p>
+              <p className="truncate text-xs text-gray-500 dark:text-gray-400">
+                {selectedCity?.availability === 'available'
+                  ? 'Zona Metropolitana de Monterrey'
+                  : 'Sin datos recientes'}
+              </p>
+            </div>
           </div>
-          <div className="min-w-0">
-            <p className="truncate text-sm font-medium text-gray-900 dark:text-white">
-              {selectedCity?.name ?? 'Selecciona una ciudad'}
-            </p>
-            <p className="truncate text-xs text-gray-500 dark:text-gray-400">
-              {selectedCity?.availability === 'available'
-                ? 'Zona Metropolitana de Monterrey'
-                : 'Sin datos recientes'}
-            </p>
-          </div>
-        </div>
-        <IoChevronDownOutline
-          className={`h-5 w-5 flex-shrink-0 text-gray-400 transition-transform duration-300 ${isOpen ? 'rotate-180 transform' : ''}`}
-        />
-      </motion.div>
+          <IoChevronDownOutline
+            className={`h-5 w-5 flex-shrink-0 text-gray-400 transition-transform duration-300 ${isOpen ? 'rotate-180 transform' : ''}`}
+          />
+        </motion.div>
+
+        <motion.button
+          whileTap={{ scale: 0.96 }}
+          className="inline-flex min-w-[3rem] shrink-0 items-center justify-center rounded-lg border border-purple-200 bg-white px-3 text-sm font-semibold text-purple-700 shadow-md transition-colors hover:bg-purple-50 disabled:cursor-wait disabled:opacity-70 dark:border-purple-800 dark:bg-slate-800 dark:text-purple-300 dark:hover:bg-purple-900/20 sm:min-w-fit sm:gap-2"
+          onClick={handleUseLocation}
+          disabled={isLocating}
+          type="button"
+          aria-label="Usar mi ubicación"
+        >
+          <IoLocateOutline className={`h-5 w-5 ${isLocating ? 'animate-pulse' : ''}`} />
+          <span className="hidden sm:inline">Usar mi ubicación</span>
+        </motion.button>
+      </div>
+
+      <AnimatePresence>
+        {locationMessage && (
+          <motion.div
+            initial={{ opacity: 0, y: -8 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -8 }}
+            className={`pointer-events-none absolute left-0 right-0 top-[calc(100%+0.5rem)] z-[1100] rounded-lg border px-3 py-2 text-xs shadow-lg sm:text-sm ${
+              locationMessageTone === 'warning'
+                ? 'border-amber-300 bg-amber-50 text-amber-900'
+                : 'border-emerald-300 bg-emerald-50 text-emerald-900'
+            }`}
+            role="status"
+          >
+            {locationMessage}
+          </motion.div>
+        )}
+      </AnimatePresence>
 
       <AnimatePresence>
         {isOpen && (

--- a/src/services/coreSignalService.ts
+++ b/src/services/coreSignalService.ts
@@ -5,24 +5,28 @@ import {
 } from '../utils/coverageUtils';
 
 const CORE_DB_SUPABASE_URL = import.meta.env.VITE_CORE_DB_SUPABASE_URL;
-const CORE_DB_SUPABASE_ANON_KEY = import.meta.env.VITE_CORE_DB_SUPABASE_ANON_KEY;
+const CORE_DB_SUPABASE_PUBLISHABLE_KEY = import.meta.env.VITE_CORE_DB_SUPABASE_PUBLISHABLE_KEY;
+const CORE_SPACE_KEY = import.meta.env.VITE_CORE_SPACE_KEY;
+const CORE_APP_KEY = import.meta.env.VITE_CORE_APP_KEY;
 
-const MTYRESPIRA_SPACE_KEY = 'mtyrespira';
-const MTYRESPIRA_APP_KEY = 'mtyrespira-web';
 const OUT_OF_COVERAGE_SIGNAL_KIND = 'out_of_coverage_geolocation';
 
 let coreDbClient: SupabaseClient | null = null;
 
 function getCoreDbClient() {
-  if (!CORE_DB_SUPABASE_URL || !CORE_DB_SUPABASE_ANON_KEY) {
+  if (!CORE_DB_SUPABASE_URL || !CORE_DB_SUPABASE_PUBLISHABLE_KEY) {
     return null;
   }
 
   if (!coreDbClient) {
-    coreDbClient = createClient(CORE_DB_SUPABASE_URL, CORE_DB_SUPABASE_ANON_KEY);
+    coreDbClient = createClient(CORE_DB_SUPABASE_URL, CORE_DB_SUPABASE_PUBLISHABLE_KEY);
   }
 
   return coreDbClient;
+}
+
+function hasCoreSignalKeys() {
+  return Boolean(CORE_SPACE_KEY && CORE_APP_KEY);
 }
 
 function getOptionalBrowserLanguage() {
@@ -67,8 +71,8 @@ export function buildOutOfCoverageDemandSignalPayload({
   }
 
   return {
-    space_key: MTYRESPIRA_SPACE_KEY,
-    app_key: MTYRESPIRA_APP_KEY,
+    space_key: CORE_SPACE_KEY,
+    app_key: CORE_APP_KEY,
     kind: OUT_OF_COVERAGE_SIGNAL_KIND,
     title: 'Out-of-coverage geolocation demand',
     summary: 'User geolocation was outside the MtyRespira supported area.',
@@ -80,7 +84,7 @@ export function buildOutOfCoverageDemandSignalPayload({
 export async function submitOutOfCoverageDemandSignal(input: OutOfCoverageDemandSignalInput) {
   const supabase = getCoreDbClient();
 
-  if (!supabase) {
+  if (!supabase || !hasCoreSignalKeys()) {
     return { ok: false, skipped: true, reason: 'core_db_config_missing' };
   }
 

--- a/src/services/coreSignalService.ts
+++ b/src/services/coreSignalService.ts
@@ -1,0 +1,95 @@
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import {
+  DistanceBucket,
+  MTYRESPIRA_COVERAGE_AREA,
+} from '../utils/coverageUtils';
+
+const CORE_DB_SUPABASE_URL = import.meta.env.VITE_CORE_DB_SUPABASE_URL;
+const CORE_DB_SUPABASE_ANON_KEY = import.meta.env.VITE_CORE_DB_SUPABASE_ANON_KEY;
+
+const MTYRESPIRA_SPACE_KEY = 'mtyrespira';
+const MTYRESPIRA_APP_KEY = 'mtyrespira-web';
+const OUT_OF_COVERAGE_SIGNAL_KIND = 'out_of_coverage_geolocation';
+
+let coreDbClient: SupabaseClient | null = null;
+
+function getCoreDbClient() {
+  if (!CORE_DB_SUPABASE_URL || !CORE_DB_SUPABASE_ANON_KEY) {
+    return null;
+  }
+
+  if (!coreDbClient) {
+    coreDbClient = createClient(CORE_DB_SUPABASE_URL, CORE_DB_SUPABASE_ANON_KEY);
+  }
+
+  return coreDbClient;
+}
+
+function getOptionalBrowserLanguage() {
+  return typeof navigator !== 'undefined' ? navigator.language : undefined;
+}
+
+function getOptionalTimezone() {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone;
+  } catch {
+    return undefined;
+  }
+}
+
+export interface OutOfCoverageDemandSignalInput {
+  nearestSupportedCity: string;
+  roundedDistanceKm: number;
+  distanceBucket: DistanceBucket;
+}
+
+export function buildOutOfCoverageDemandSignalPayload({
+  nearestSupportedCity,
+  roundedDistanceKm,
+  distanceBucket,
+}: OutOfCoverageDemandSignalInput) {
+  const data: Record<string, string | number> = {
+    nearest_supported_city: nearestSupportedCity,
+    distance_to_nearest_km: roundedDistanceKm,
+    distance_bucket: distanceBucket,
+    coverage_area: MTYRESPIRA_COVERAGE_AREA,
+  };
+
+  const browserLanguage = getOptionalBrowserLanguage();
+  const timezone = getOptionalTimezone();
+
+  if (browserLanguage) {
+    data.browser_language = browserLanguage;
+  }
+
+  if (timezone) {
+    data.timezone = timezone;
+  }
+
+  return {
+    space_key: MTYRESPIRA_SPACE_KEY,
+    app_key: MTYRESPIRA_APP_KEY,
+    kind: OUT_OF_COVERAGE_SIGNAL_KIND,
+    title: 'Out-of-coverage geolocation demand',
+    summary: 'User geolocation was outside the MtyRespira supported area.',
+    priority: 'low',
+    data,
+  };
+}
+
+export async function submitOutOfCoverageDemandSignal(input: OutOfCoverageDemandSignalInput) {
+  const supabase = getCoreDbClient();
+
+  if (!supabase) {
+    return { ok: false, skipped: true, reason: 'core_db_config_missing' };
+  }
+
+  const payload = buildOutOfCoverageDemandSignalPayload(input);
+  const { data, error } = await supabase.rpc('submit_signal', { payload });
+
+  if (error) {
+    return { ok: false, skipped: false, reason: 'submit_signal_error', error };
+  }
+
+  return { ok: true, skipped: false, data };
+}

--- a/src/utils/coverageUtils.ts
+++ b/src/utils/coverageUtils.ts
@@ -1,0 +1,86 @@
+import { MONTERREY_LOCATIONS_WITH_COORDS } from '../services/apiService';
+
+export const OUT_OF_COVERAGE_KM = 100;
+export const MTYRESPIRA_COVERAGE_AREA = 'mty_metro';
+
+type CityOption = (typeof MONTERREY_LOCATIONS_WITH_COORDS)[number];
+
+export type DistanceBucket = '100_250' | '250_500' | '500_1000' | '1000_plus';
+
+export interface NearestSupportedCityResult {
+  city: CityOption;
+  distanceKm: number;
+  roundedDistanceKm: number;
+  distanceBucket: DistanceBucket;
+}
+
+function toRadians(degrees: number) {
+  return (degrees * Math.PI) / 180;
+}
+
+export function calculateDistanceKm(
+  fromLatitude: number,
+  fromLongitude: number,
+  toLatitude: number,
+  toLongitude: number,
+) {
+  const earthRadiusKm = 6371;
+  const latitudeDelta = toRadians(toLatitude - fromLatitude);
+  const longitudeDelta = toRadians(toLongitude - fromLongitude);
+  const fromLatitudeRad = toRadians(fromLatitude);
+  const toLatitudeRad = toRadians(toLatitude);
+
+  const haversine = Math.sin(latitudeDelta / 2) ** 2
+    + Math.cos(fromLatitudeRad)
+      * Math.cos(toLatitudeRad)
+      * Math.sin(longitudeDelta / 2) ** 2;
+
+  return earthRadiusKm * 2 * Math.atan2(Math.sqrt(haversine), Math.sqrt(1 - haversine));
+}
+
+export function getDistanceBucket(distanceKm: number): DistanceBucket {
+  if (distanceKm < 250) {
+    return '100_250';
+  }
+
+  if (distanceKm < 500) {
+    return '250_500';
+  }
+
+  if (distanceKm < 1000) {
+    return '500_1000';
+  }
+
+  return '1000_plus';
+}
+
+export function findNearestSupportedCity(
+  latitude: number,
+  longitude: number,
+  cities: CityOption[] = MONTERREY_LOCATIONS_WITH_COORDS,
+): NearestSupportedCityResult | null {
+  if (cities.length === 0) {
+    return null;
+  }
+
+  const nearest = cities.reduce<NearestSupportedCityResult | null>((currentNearest, city) => {
+    const distanceKm = calculateDistanceKm(latitude, longitude, city.latitude, city.longitude);
+
+    if (!currentNearest || distanceKm < currentNearest.distanceKm) {
+      return {
+        city,
+        distanceKm,
+        roundedDistanceKm: Math.round(distanceKm),
+        distanceBucket: getDistanceBucket(distanceKm),
+      };
+    }
+
+    return currentNearest;
+  }, null);
+
+  return nearest;
+}
+
+export function isOutOfCoverage(distanceKm: number) {
+  return distanceKm > OUT_OF_COVERAGE_KM;
+}


### PR DESCRIPTION
## Summary
- Adds out-of-coverage detection for the city selector geolocation flow.
- Keeps manual city selection available when user is outside the supported coverage area.
- Sends anonymous demand signals to Elelier Core DB through public `submit_signal` using the existing `kind/summary/data` contract.
- Adds a non-blocking toast message that overlays the selector and disappears automatically.
- Adds `.env.example` with Core DB public env names.

## Required frontend env vars
```env
VITE_CORE_DB_SUPABASE_URL=https://adntcjusglrkeolucbyk.supabase.co
VITE_CORE_DB_SUPABASE_PUBLISHABLE_KEY=<Core DB publishable key>
VITE_CORE_SPACE_KEY=mtyrespira
VITE_CORE_APP_KEY=mtyrespira-web
```

## Privacy
- Does not send exact lat/lon.
- Does not send IP.
- Does not send person/name/email/phone.
- Sends only nearest supported city, rounded distance, distance bucket, coverage area, and optional browser language/timezone.

## Contract notes
- Does not touch `get_latest_air_quality_per_city`.
- Does not write to the MtyRespira environmental database.
- Uses Core DB publishable key only; no service_role.
- Uses `VITE_CORE_SPACE_KEY` and `VITE_CORE_APP_KEY` instead of hardcoded Core DB consumer keys.
- If Core DB config or RPC submission fails, UX continues without blocking manual selection.

## Validation
- Static review of payload against Core DB `contracts/signal-submit.v1.schema.json`.
- Core DB live seed was merged in elelier/elelier-core-db#7 and applied as migration `007_seed_mtyrespira_web_app`.

## Rollback
Revert this PR. Core DB seed can remain active without frontend callers, or disable the `mtyrespira` / `mtyrespira-web` link in Core DB if needed.