### PR TITLE
feat: add city deep links and persistent selection

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,10 +4,10 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="Monitoreo de la calidad del aire en Monterrey, Nuevo León disponible" />
+  <meta name="description" content="Consulta AQI, contaminante principal y recomendaciones por municipio en la Zona Metropolitana de Monterrey." />
   <meta name="theme-color" content="#ffffff">
-  <meta property="og:title" content="MonterreyRespira - Calidad del Aire en Monterrey" />
-  <meta property="og:description" content="Monitoreo disponible de la calidad del aire en Monterrey y su área metropolitana" />
+  <meta property="og:title" content="MonterreyRespira - Calidad del aire en la Zona Metropolitana" />
+  <meta property="og:description" content="Consulta AQI, contaminante principal y recomendaciones por municipio." />
   <meta property="og:image" content="https://mtyrespira.elelier.com/images/seo/share-image.png" />
   <meta property="og:image:width" content="1200" />
   <meta property="og:image:height" content="630" />
@@ -17,7 +17,7 @@
 
   <link rel="icon" type="image/png" href="/favicon.png" />
   <link rel="manifest" href="/manifest.json">
-  <title>MonterreyRespira - Calidad del Aire disponible</title>
+  <title>MonterreyRespira - Calidad del aire en la Zona Metropolitana</title>
 </head>
 
 <body>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -12,12 +12,14 @@ interface LayoutProps {
 }
 
 export default function Layout({ children }: LayoutProps) {
-  const { theme, airQualityData } = useAirQuality();
+  const { theme, airQualityData, selectedCity } = useAirQuality();
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const location = useLocation();
 
-  // Obtener la ciudad actual para el título
-  const currentCity = 'Monterrey';
+  // Obtener la ciudad actual para el título y compartir.
+  const currentCity = selectedCity.name;
+  const shareTitle = `MonterreyRespira - Calidad del Aire en ${currentCity}`;
+  const shareDescription = `Consulta la calidad del aire en ${currentCity} con MtyRespira. Revisa AQI, contaminante principal y recomendaciones de salud.`;
 
   // Obtener la imagen de compartición basada en la calidad del aire
   const getShareImage = () => {
@@ -78,8 +80,8 @@ export default function Layout({ children }: LayoutProps) {
   return (
     <>
       <Metadata
-        title={`MonterreyRespira - Calidad del Aire en ${currentCity}`}
-        description={`Monitoreo de la calidad del aire disponible en ${currentCity} y su area metropolitana. Conozca los niveles de contaminantes y obtenga recomendaciones para proteger su salud.`}
+        title={shareTitle}
+        description={shareDescription}
         keywords={`calidad del aire, contaminación, ${currentCity}, ambiente, monitoreo, salud`}
         image={getShareImage()}
         type="website"
@@ -195,8 +197,8 @@ export default function Layout({ children }: LayoutProps) {
                 onClick={() => {
                   if (navigator.share) {
                     navigator.share({
-                      title: `MonterreyRespira - Calidad del Aire en ${currentCity}`,
-                      text: `Monitoreo de la calidad del aire disponible en ${currentCity}. Conozca los niveles de contaminantes y obtenga recomendaciones para proteger su salud.`,
+                      title: shareTitle,
+                      text: shareDescription,
                       url: window.location.href
                     })
                     .catch(console.error);

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -14,16 +14,17 @@ interface LayoutProps {
 }
 
 const CITY_SHARE_SIGNAL_FAILED_MESSAGE = 'No se pudo registrar señal anónima de compartir ciudad:';
+const SOCIAL_PREVIEW_TITLE = 'MonterreyRespira - Calidad del aire en la Zona Metropolitana';
+const SOCIAL_PREVIEW_DESCRIPTION = 'Consulta AQI, contaminante principal y recomendaciones por municipio.';
 
 export default function Layout({ children }: LayoutProps) {
   const { theme, airQualityData, selectedCity } = useAirQuality();
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const location = useLocation();
 
-  // Obtener la ciudad actual para el título y compartir.
+  // Obtener la ciudad actual para el mensaje de compartir.
   const currentCity = selectedCity.name;
-  const shareTitle = `MonterreyRespira - Calidad del Aire en ${currentCity}`;
-  const shareDescription = `Consulta la calidad del aire en ${currentCity} con MtyRespira. Revisa AQI, contaminante principal y recomendaciones de salud.`;
+  const shareDescription = `Calidad del aire en ${currentCity}:\nRevisa AQI, contaminante principal y recomendaciones en MtyRespira.`;
 
   const submitShareSignal = (shareMethod: CityShareMethod) => {
     void submitCityShareSignal({
@@ -98,9 +99,9 @@ export default function Layout({ children }: LayoutProps) {
   return (
     <>
       <Metadata
-        title={shareTitle}
-        description={shareDescription}
-        keywords={`calidad del aire, contaminación, ${currentCity}, ambiente, monitoreo, salud`}
+        title={SOCIAL_PREVIEW_TITLE}
+        description={SOCIAL_PREVIEW_DESCRIPTION}
+        keywords={`calidad del aire, contaminación, ${currentCity}, zona metropolitana, ambiente, monitoreo, salud`}
         image={getShareImage()}
         type="website"
       />
@@ -215,7 +216,7 @@ export default function Layout({ children }: LayoutProps) {
                 onClick={() => {
                   if (navigator.share) {
                     navigator.share({
-                      title: shareTitle,
+                      title: SOCIAL_PREVIEW_TITLE,
                       text: shareDescription,
                       url: window.location.href
                     })

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -6,10 +6,14 @@ import { Link, useLocation } from 'react-router-dom';
 import { IoHomeOutline, IoInformationCircleOutline, IoLayersOutline, IoLinkOutline, IoMenuOutline, IoShareOutline } from 'react-icons/io5';
 import { Metadata } from './seo/Metadata';
 import { Analytics } from './seo/Analytics';
+import { getCitySlug } from '../utils/cityRoutingUtils';
+import { CityShareMethod, submitCityShareSignal } from '../services/coreSignalService';
 
 interface LayoutProps {
   children: ReactNode;
 }
+
+const CITY_SHARE_SIGNAL_FAILED_MESSAGE = 'No se pudo registrar señal anónima de compartir ciudad:';
 
 export default function Layout({ children }: LayoutProps) {
   const { theme, airQualityData, selectedCity } = useAirQuality();
@@ -20,6 +24,20 @@ export default function Layout({ children }: LayoutProps) {
   const currentCity = selectedCity.name;
   const shareTitle = `MonterreyRespira - Calidad del Aire en ${currentCity}`;
   const shareDescription = `Consulta la calidad del aire en ${currentCity} con MtyRespira. Revisa AQI, contaminante principal y recomendaciones de salud.`;
+
+  const submitShareSignal = (shareMethod: CityShareMethod) => {
+    void submitCityShareSignal({
+      cityId: selectedCity.city_id,
+      cityName: selectedCity.name,
+      citySlug: getCitySlug(selectedCity),
+      route: window.location.pathname,
+      shareMethod,
+      aqiUs: airQualityData?.aqi ?? null,
+      measurementFreshness: airQualityData?.measurementFreshness ?? 'unknown',
+    }).catch((error: unknown) => {
+      console.warn(CITY_SHARE_SIGNAL_FAILED_MESSAGE, error);
+    });
+  };
 
   // Obtener la imagen de compartición basada en la calidad del aire
   const getShareImage = () => {
@@ -201,11 +219,19 @@ export default function Layout({ children }: LayoutProps) {
                       text: shareDescription,
                       url: window.location.href
                     })
-                    .catch(console.error);
+                      .then(() => submitShareSignal('native_share'))
+                      .catch((error: unknown) => {
+                        if (error instanceof DOMException && error.name === 'AbortError') {
+                          return;
+                        }
+
+                        console.error(error);
+                      });
                   } else {
                     // Copiar URL al portapapeles como alternativa
                     navigator.clipboard.writeText(window.location.href)
                       .then(() => {
+                        submitShareSignal('clipboard_fallback');
                         alert('URL copiada al portapapeles');
                       })
                       .catch(console.error);

--- a/src/context/AirQualityContext.tsx
+++ b/src/context/AirQualityContext.tsx
@@ -12,6 +12,13 @@ import {
   isAirQualityServiceError,
   MONTERREY_LOCATIONS_WITH_COORDS,
 } from '../services/apiService';
+import {
+  getCityFromSearch,
+  readStoredCityId,
+  updateCityQueryParam,
+  writeStoredCityId,
+  findCityById,
+} from '../utils/cityRoutingUtils';
 
 type CityOption = (typeof MONTERREY_LOCATIONS_WITH_COORDS)[number];
 
@@ -265,6 +272,16 @@ function writeCachedData(cityDataArray: CityAirQualityData[]) {
   localStorage.setItem(`${CACHE_KEY}_timestamp`, Date.now().toString());
 }
 
+function resolveInitialCity(locations: readonly CityOption[], defaultCity: CityOption): CityOption {
+  const cityFromQueryParam = getCityFromSearch(locations, window.location.search);
+
+  if (cityFromQueryParam) {
+    return cityFromQueryParam;
+  }
+
+  return findCityById(locations, readStoredCityId()) ?? defaultCity;
+}
+
 export function AirQualityProvider({ children }: AirQualityProviderProps) {
   const locations = useMemo(() => MONTERREY_LOCATIONS_WITH_COORDS, []);
   const defaultCity = locations[0];
@@ -278,9 +295,17 @@ export function AirQualityProvider({ children }: AirQualityProviderProps) {
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
   const [theme, setTheme] = useState<AirQualityTheme | null>(null);
-  const [selectedCity, setSelectedCity] = useState<CityOption>(defaultCity);
+  const [selectedCity, setSelectedCity] = useState<CityOption>(() => (
+    resolveInitialCity(locations, defaultCity)
+  ));
 
   const cityOptions = useMemo(() => buildCityOptions(cityDataArray), [cityDataArray]);
+
+  const persistSelectedCity = useCallback((city: CityOption) => {
+    setSelectedCity(city);
+    writeStoredCityId(city);
+    updateCityQueryParam(city);
+  }, []);
 
   const applyTransformedData = useCallback((dataRows: CityAirQualityData[], city: CityOption) => {
     const options = buildCityOptions(dataRows);
@@ -289,14 +314,14 @@ export function AirQualityProvider({ children }: AirQualityProviderProps) {
     const transformedData = transformApiResponse(dataRows, nextCity);
 
     if (nextCity.city_id !== city.city_id) {
-      setSelectedCity(nextCity);
+      persistSelectedCity(nextCity);
     }
 
     setCityDataArray(dataRows);
     setAirQualityData(transformedData);
     setTheme(getAirQualityTheme(transformedData.status));
     setError(null);
-  }, []);
+  }, [persistSelectedCity]);
 
   const fetchAirQualityData = useCallback(async (skipCache = false) => {
     if (!skipCache) {
@@ -346,13 +371,13 @@ export function AirQualityProvider({ children }: AirQualityProviderProps) {
 
     if (option && option.availability !== 'available') {
       const degradedData = transformApiResponse(cityDataArray, city);
-      setSelectedCity(city);
+      persistSelectedCity(city);
       setAirQualityData(degradedData);
       setTheme(getAirQualityTheme('unknown'));
       return;
     }
 
-    setSelectedCity(city);
+    persistSelectedCity(city);
   };
 
   useEffect(() => {

--- a/src/services/coreSignalService.ts
+++ b/src/services/coreSignalService.ts
@@ -3,6 +3,7 @@ import {
   DistanceBucket,
   MTYRESPIRA_COVERAGE_AREA,
 } from '../utils/coverageUtils';
+import { MeasurementFreshness } from '../types';
 
 const CORE_DB_SUPABASE_URL = import.meta.env.VITE_CORE_DB_SUPABASE_URL;
 const CORE_DB_SUPABASE_PUBLISHABLE_KEY = import.meta.env.VITE_CORE_DB_SUPABASE_PUBLISHABLE_KEY;
@@ -10,6 +11,7 @@ const CORE_SPACE_KEY = import.meta.env.VITE_CORE_SPACE_KEY;
 const CORE_APP_KEY = import.meta.env.VITE_CORE_APP_KEY;
 
 const OUT_OF_COVERAGE_SIGNAL_KIND = 'out_of_coverage_geolocation';
+const CITY_SHARE_SIGNAL_KIND = 'city_share';
 
 let coreDbClient: SupabaseClient | null = null;
 
@@ -41,6 +43,21 @@ function getOptionalTimezone() {
   }
 }
 
+function addBrowserContext(data: Record<string, string | number | null>) {
+  const browserLanguage = getOptionalBrowserLanguage();
+  const timezone = getOptionalTimezone();
+
+  if (browserLanguage) {
+    data.browser_language = browserLanguage;
+  }
+
+  if (timezone) {
+    data.timezone = timezone;
+  }
+
+  return data;
+}
+
 export interface OutOfCoverageDemandSignalInput {
   nearestSupportedCity: string;
   roundedDistanceKm: number;
@@ -52,23 +69,12 @@ export function buildOutOfCoverageDemandSignalPayload({
   roundedDistanceKm,
   distanceBucket,
 }: OutOfCoverageDemandSignalInput) {
-  const data: Record<string, string | number> = {
+  const data = addBrowserContext({
     nearest_supported_city: nearestSupportedCity,
     distance_to_nearest_km: roundedDistanceKm,
     distance_bucket: distanceBucket,
     coverage_area: MTYRESPIRA_COVERAGE_AREA,
-  };
-
-  const browserLanguage = getOptionalBrowserLanguage();
-  const timezone = getOptionalTimezone();
-
-  if (browserLanguage) {
-    data.browser_language = browserLanguage;
-  }
-
-  if (timezone) {
-    data.timezone = timezone;
-  }
+  });
 
   return {
     space_key: CORE_SPACE_KEY,
@@ -89,6 +95,65 @@ export async function submitOutOfCoverageDemandSignal(input: OutOfCoverageDemand
   }
 
   const payload = buildOutOfCoverageDemandSignalPayload(input);
+  const { data, error } = await supabase.rpc('submit_signal', { payload });
+
+  if (error) {
+    return { ok: false, skipped: false, reason: 'submit_signal_error', error };
+  }
+
+  return { ok: true, skipped: false, data };
+}
+
+export type CityShareMethod = 'native_share' | 'clipboard_fallback';
+
+export interface CityShareSignalInput {
+  cityId: number;
+  cityName: string;
+  citySlug: string;
+  route: string;
+  shareMethod: CityShareMethod;
+  aqiUs: number | null;
+  measurementFreshness: MeasurementFreshness;
+}
+
+export function buildCityShareSignalPayload({
+  cityId,
+  cityName,
+  citySlug,
+  route,
+  shareMethod,
+  aqiUs,
+  measurementFreshness,
+}: CityShareSignalInput) {
+  const data = addBrowserContext({
+    city_id: cityId,
+    city_name: cityName,
+    city_slug: citySlug,
+    route,
+    share_method: shareMethod,
+    aqi_us: aqiUs,
+    measurement_freshness: measurementFreshness,
+  });
+
+  return {
+    space_key: CORE_SPACE_KEY,
+    app_key: CORE_APP_KEY,
+    kind: CITY_SHARE_SIGNAL_KIND,
+    title: 'City deep link shared',
+    summary: 'User shared a MtyRespira city deep link.',
+    priority: 'low',
+    data,
+  };
+}
+
+export async function submitCityShareSignal(input: CityShareSignalInput) {
+  const supabase = getCoreDbClient();
+
+  if (!supabase || !hasCoreSignalKeys()) {
+    return { ok: false, skipped: true, reason: 'core_db_config_missing' };
+  }
+
+  const payload = buildCityShareSignalPayload(input);
   const { data, error } = await supabase.rpc('submit_signal', { payload });
 
   if (error) {

--- a/src/utils/cityRoutingUtils.ts
+++ b/src/utils/cityRoutingUtils.ts
@@ -1,0 +1,84 @@
+import { CitySelectorOption } from '../types';
+
+export const SELECTED_CITY_STORAGE_KEY = 'mtyRespiraSelectedCityId';
+export const CITY_QUERY_PARAM = 'city';
+
+export interface CanonicalCity {
+  city_id: number;
+  name: string;
+}
+
+export function slugifyCityName(cityName: string) {
+  return cityName
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+export function findCityBySlug<TCity extends CanonicalCity>(
+  cities: readonly TCity[],
+  slug: string | null | undefined,
+): TCity | undefined {
+  if (!slug) {
+    return undefined;
+  }
+
+  return cities.find((city) => slugifyCityName(city.name) === slug);
+}
+
+export function findCityById<TCity extends CanonicalCity>(
+  cities: readonly TCity[],
+  cityId: number | null | undefined,
+): TCity | undefined {
+  if (cityId === null || cityId === undefined) {
+    return undefined;
+  }
+
+  return cities.find((city) => city.city_id === cityId);
+}
+
+export function getCitySlug(city: CanonicalCity) {
+  return slugifyCityName(city.name);
+}
+
+export function getCitySlugFromSearch(search: string) {
+  return new URLSearchParams(search).get(CITY_QUERY_PARAM);
+}
+
+export function getCityFromSearch<TCity extends CanonicalCity>(cities: readonly TCity[], search: string) {
+  return findCityBySlug(cities, getCitySlugFromSearch(search));
+}
+
+export function readStoredCityId() {
+  const storedCityId = window.localStorage.getItem(SELECTED_CITY_STORAGE_KEY);
+
+  if (!storedCityId) {
+    return null;
+  }
+
+  const parsedCityId = Number(storedCityId);
+
+  return Number.isInteger(parsedCityId) ? parsedCityId : null;
+}
+
+export function writeStoredCityId(city: CanonicalCity) {
+  window.localStorage.setItem(SELECTED_CITY_STORAGE_KEY, String(city.city_id));
+}
+
+export function updateCityQueryParam(city: CanonicalCity) {
+  const nextSlug = getCitySlug(city);
+  const currentUrl = new URL(window.location.href);
+
+  if (currentUrl.searchParams.get(CITY_QUERY_PARAM) === nextSlug) {
+    return;
+  }
+
+  currentUrl.searchParams.set(CITY_QUERY_PARAM, nextSlug);
+  window.history.replaceState(window.history.state, '', currentUrl.toString());
+}
+
+export function isCanonicalCity(city: CanonicalCity, cityOptions: CitySelectorOption[]) {
+  return cityOptions.some((option) => option.city_id === city.city_id);
+}


### PR DESCRIPTION
## Resumen
- Agrega helper centralizado para slugs canónicos de ciudad, lectura de `?city=...`, persistencia en `localStorage` y actualización de URL sin recargar.
- Inicializa la ciudad seleccionada desde query param válido; si no existe, restaura la última ciudad válida guardada; si nada aplica, conserva el fallback actual.
- Mantiene `city_id` como identidad interna y reutiliza `changeCity`, por lo que selector, mapa y geolocalización actualizan URL + storage.

## Contrato
Frontend-only. No cambia Supabase schema, RPC `get_latest_air_quality_per_city`, pipeline, Core DB, datos ambientales ni service_role.

## Validación esperada
- `npm ci`
- `npm run lint`
- `npx tsc --noEmit`
- `npm run build`
- Playwright desktop/mobile:
  - abrir `/?city=san-pedro-garza-garcia` selecciona San Pedro Garza Garcia
  - cambiar a Monterrey actualiza URL
  - click en pin de mapa actualiza ciudad y URL
  - geolocalización exitosa actualiza ciudad y URL
  - query inválido no rompe dashboard
  - reload conserva ciudad por query/localStorage
  - no aparece “tiempo real”
  - no aparece “AirVisual”

## Rollback
Revertir este PR.