### PR TITLE
feat: centralize AQI design tokens and copy

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -2,6 +2,7 @@ import { ReactNode, useEffect, useState } from 'react';
 import { motion } from 'framer-motion';
 import { useAirQuality } from '../context/AirQualityContext';
 import { getMainLogoIcon, getPollutantInfo } from '../utils/airQualityUtils';
+import { AQI_STATUS_SHARE_LABELS } from '../utils/aqiDesignTokens';
 import { Link, useLocation } from 'react-router-dom';
 import { IoHomeOutline, IoInformationCircleOutline, IoLayersOutline, IoLinkOutline, IoMenuOutline, IoShareOutline } from 'react-icons/io5';
 import { Metadata } from './seo/Metadata';
@@ -17,15 +18,6 @@ interface LayoutProps {
 const CITY_SHARE_SIGNAL_FAILED_MESSAGE = 'No se pudo registrar señal anónima de compartir ciudad:';
 const SOCIAL_PREVIEW_TITLE = 'MonterreyRespira - Calidad del aire en la Zona Metropolitana';
 const SOCIAL_PREVIEW_DESCRIPTION = 'Consulta AQI, contaminante principal y recomendaciones por municipio.';
-const AIR_QUALITY_STATUS_SHARE_LABELS: Record<AirQualityStatus, string> = {
-  good: 'Buena',
-  moderate: 'Moderada',
-  'unhealthy-sensitive': 'Dañina para grupos sensibles',
-  unhealthy: 'Dañina',
-  'very-unhealthy': 'Muy dañina',
-  hazardous: 'Peligrosa',
-  unknown: 'No disponible',
-};
 
 const hasShareableAqi = (aqi: number | null | undefined, status: AirQualityStatus): aqi is number => {
   return status !== 'unknown' && typeof aqi === 'number' && Number.isFinite(aqi);
@@ -50,7 +42,7 @@ const buildCitySnapshotShareDescription = (
   const pollutantLabel = formatMainPollutantForShare(airQualityData.main_pollutant_us);
   const snapshotParts = [
     `AQI ${airQualityData.aqi}`,
-    AIR_QUALITY_STATUS_SHARE_LABELS[airQualityData.status],
+    AQI_STATUS_SHARE_LABELS[airQualityData.status],
     pollutantLabel,
   ].filter(Boolean);
 

--- a/src/utils/airQualityUtils.ts
+++ b/src/utils/airQualityUtils.ts
@@ -1,4 +1,10 @@
-import { AirQualityStatus, AirQualityTheme, RecommendationInfo } from '../types';
+import type { AirQualityStatus, AirQualityTheme, RecommendationInfo } from '../types';
+import {
+  AQI_RANGE_TOKENS,
+  AQI_RECOMMENDATIONS,
+  AQI_STATUS_DESCRIPTIONS,
+  AQI_THEME_TOKENS,
+} from './aqiDesignTokens';
 import icon01d from '../assets/weather-icons/01d.png';
 import icon01n from '../assets/weather-icons/01n.png';
 import icon02d from '../assets/weather-icons/02d.png';
@@ -30,29 +36,21 @@ export function getMainLogoIcon(): string {
 }
 
 export function getAirQualityStatus(aqi: number | null | undefined): AirQualityStatus {
-  if (aqi === null || aqi === undefined) {
+  if (aqi === null || aqi === undefined || !Number.isFinite(aqi)) {
     return 'unknown';
   }
 
-  if (aqi <= 50) {
-    return 'good';
-  } else if (aqi <= 100) {
-    return 'moderate';
-  } else if (aqi <= 150) {
-    return 'unhealthy-sensitive';
-  } else if (aqi <= 200) {
-    return 'unhealthy';
-  } else if (aqi <= 300) {
-    return 'very-unhealthy';
-  } else {
-    return 'hazardous';
-  }
+  const range = AQI_RANGE_TOKENS.find(({ min, max }) => {
+    return aqi >= min && (max === null || aqi <= max);
+  });
+
+  return range?.status ?? 'unknown';
 }
 
 export function getHumidityIcon(humidity: number): string {
   if (humidity < 40) {
     return iconmidhum;
-  } else if (humidity >= 40 && humidity <= 70) {
+  } else if (humidity <= 70) {
     return iconmidhum;
   } else {
     return iconhighhum;
@@ -63,7 +61,12 @@ export function getWindIcon(
   windSpeedMs: number | null | undefined,
   windDirectionDeg: number | null | undefined,
 ): { icon: string; rotation?: number } {
-  if (windSpeedMs === null || windSpeedMs === undefined || windDirectionDeg === null || windDirectionDeg === undefined) {
+  if (
+    windSpeedMs === null ||
+    windSpeedMs === undefined ||
+    windDirectionDeg === null ||
+    windDirectionDeg === undefined
+  ) {
     return { icon: '' };
   }
 
@@ -86,195 +89,11 @@ export function getWindIcon(
 }
 
 export const getAirQualityTheme = (status: AirQualityStatus): AirQualityTheme => {
-  switch (status) {
-    case 'good':
-      return {
-        primary: '#4ade80',
-        secondary: '#10b981',
-        background: '#f0fdf4',
-        text: '#166534',
-        gradient: 'from-green-400 to-emerald-500',
-      };
-    case 'moderate':
-      return {
-        primary: '#fbbf24',
-        secondary: '#f59e0b',
-        background: '#fffbeb',
-        text: '#92400e',
-        gradient: 'from-amber-400 to-yellow-500',
-      };
-    case 'unhealthy-sensitive':
-      return {
-        primary: '#fb923c',
-        secondary: '#f97316',
-        background: '#fff7ed',
-        text: '#9a3412',
-        gradient: 'from-orange-400 to-orange-500',
-      };
-    case 'unhealthy':
-      return {
-        primary: '#f87171',
-        secondary: '#ef4444',
-        background: '#fef2f2',
-        text: '#b91c1c',
-        gradient: 'from-red-400 to-red-500',
-      };
-    case 'very-unhealthy':
-      return {
-        primary: '#c084fc',
-        secondary: '#a855f7',
-        background: '#faf5ff',
-        text: '#7e22ce',
-        gradient: 'from-purple-400 to-purple-500',
-      };
-    case 'hazardous':
-      return {
-        primary: '#9f1239',
-        secondary: '#881337',
-        background: '#fff1f2',
-        text: '#9f1239',
-        gradient: 'from-rose-700 to-rose-800',
-      };
-    case 'unknown':
-      return {
-        primary: '#64748b',
-        secondary: '#475569',
-        background: '#f8fafc',
-        text: '#334155',
-        gradient: 'from-slate-400 to-slate-500',
-      };
-  }
+  return AQI_THEME_TOKENS[status];
 };
 
 export const getRecommendations = (status: AirQualityStatus): RecommendationInfo[] => {
-  switch (status) {
-    case 'good':
-      return [
-        {
-          icon: 'IoSunny',
-          title: 'Actividades al aire libre',
-          description: 'Hoy es seguro realizar actividades al aire libre, ¡disfruta del buen clima!',
-        },
-        {
-          icon: 'IoWalk',
-          title: 'Ejercicio',
-          description: 'Condiciones ideales para hacer ejercicio en exteriores.',
-        },
-        {
-          icon: 'IoHappy',
-          title: 'Calidad del aire',
-          description: 'La calidad del aire es excelente, sin riesgos para la salud.',
-        },
-      ];
-    case 'moderate':
-      return [
-        {
-          icon: 'IoSunny',
-          title: 'Actividades al aire libre',
-          description: 'Puedes realizar actividades al aire libre, pero con moderación.',
-        },
-        {
-          icon: 'IoWalk',
-          title: 'Ejercicio',
-          description: 'Personas sensibles deben considerar reducir el ejercicio intenso al aire libre.',
-        },
-        {
-          icon: 'IoWarning',
-          title: 'Precaución',
-          description: 'Personas con condiciones respiratorias deben estar atentas a síntomas.',
-        },
-      ];
-    case 'unhealthy-sensitive':
-      return [
-        {
-          icon: 'IoAlert',
-          title: 'Grupos sensibles',
-          description: 'Niños, adultos mayores y personas con problemas respiratorios deben limitar el tiempo al aire libre.',
-        },
-        {
-          icon: 'IoWalk',
-          title: 'Ejercicio',
-          description: 'Considera realizar ejercicio en interiores o reducir la intensidad.',
-        },
-        {
-          icon: 'IoWarning',
-          title: 'Monitoreo',
-          description: 'Mantente informado sobre el nivel de contaminación a lo largo del día.',
-        },
-      ];
-    case 'unhealthy':
-      return [
-        {
-          icon: 'IoAlert',
-          title: 'Limita exposición',
-          description: 'Evita ejercicio en exteriores y reduce actividades al aire libre.',
-        },
-        {
-          icon: 'IoHome',
-          title: 'Interior',
-          description: 'Mantén ventanas cerradas para reducir la entrada de aire contaminado.',
-        },
-        {
-          icon: 'IoMedical',
-          title: 'Salud',
-          description: 'Usa cubrebocas en exteriores, especialmente si tienes condiciones respiratorias.',
-        },
-      ];
-    case 'very-unhealthy':
-      return [
-        {
-          icon: 'IoWarning',
-          title: 'Evita exteriores',
-          description: 'Permanece en interiores y evita cualquier actividad física al aire libre.',
-        },
-        {
-          icon: 'IoHome',
-          title: 'En casa',
-          description: 'Mantén todas las ventanas cerradas y considera usar purificador de aire.',
-        },
-        {
-          icon: 'IoMedical',
-          title: 'Protección',
-          description: 'Usa cubrebocas N95 si debes salir, la contaminación es peligrosa.',
-        },
-      ];
-    case 'hazardous':
-      return [
-        {
-          icon: 'IoWarning',
-          title: 'Emergencia',
-          description: 'Condiciones de emergencia sanitaria, evita completamente salir de casa.',
-        },
-        {
-          icon: 'IoHome',
-          title: 'Refugio',
-          description: 'Permanece en interiores, sella ventanas y puertas si es posible.',
-        },
-        {
-          icon: 'IoMedical',
-          title: 'Protección',
-          description: 'Si sales, usa cubrebocas N95 y limita tu tiempo de exposición al mínimo.',
-        },
-      ];
-    case 'unknown':
-      return [
-        {
-          icon: 'IoHelpCircle',
-          title: 'Dato no disponible',
-          description: 'No hay una lectura confiable para esta ciudad en este momento.',
-        },
-        {
-          icon: 'IoRefresh',
-          title: 'Intenta actualizar',
-          description: 'Puedes refrescar la consulta o revisar otra ciudad monitoreada.',
-        },
-        {
-          icon: 'IoInformationCircle',
-          title: 'Consulta fuentes oficiales',
-          description: 'Si necesitas tomar una decisión sensible, revisa también fuentes oficiales.',
-        },
-      ];
-  }
+  return AQI_RECOMMENDATIONS[status];
 };
 
 export const getWeatherIconUrl = (iconCode: string | null | undefined): string | undefined => {
@@ -303,22 +122,7 @@ export const getWeatherIconUrl = (iconCode: string | null | undefined): string |
 };
 
 export const getAQIDescription = (status: AirQualityStatus): string => {
-  switch (status) {
-    case 'good':
-      return 'La calidad del aire es satisfactoria y representa poco o ningún riesgo para la salud.';
-    case 'moderate':
-      return 'La calidad del aire es aceptable, pero puede haber un riesgo moderado para algunas personas sensibles.';
-    case 'unhealthy-sensitive':
-      return 'Miembros de grupos sensibles pueden experimentar efectos en la salud. El público en general no suele verse afectado.';
-    case 'unhealthy':
-      return 'Todo el mundo puede comenzar a experimentar efectos en la salud. Las personas sensibles pueden experimentar efectos más graves.';
-    case 'very-unhealthy':
-      return 'Advertencias sanitarias de condiciones de emergencia. Es más probable que toda la población se vea afectada.';
-    case 'hazardous':
-      return 'Alerta sanitaria: todos pueden experimentar efectos más graves para la salud. Se recomienda evitar cualquier actividad al aire libre.';
-    case 'unknown':
-      return 'No hay una lectura confiable disponible para esta ciudad en este momento.';
-  }
+  return AQI_STATUS_DESCRIPTIONS[status];
 };
 
 export const getPollutantInfo = (pollutant: string): { name: string; description: string } => {
@@ -327,28 +131,33 @@ export const getPollutantInfo = (pollutant: string): { name: string; description
     case 'p2':
       return {
         name: 'PM2.5',
-        description: 'Partículas finas con un diámetro de 2.5 micrómetros o menos, que pueden penetrar profundamente en los pulmones.',
+        description:
+          'Partículas finas con un diámetro de 2.5 micrómetros o menos, que pueden penetrar profundamente en los pulmones.',
       };
     case 'pm10':
     case 'p1':
       return {
         name: 'PM10',
-        description: 'Partículas inhalables con un diámetro de 10 micrómetros o menos, que pueden entrar en los pulmones.',
+        description:
+          'Partículas inhalables con un diámetro de 10 micrómetros o menos, que pueden entrar en los pulmones.',
       };
     case 'o3':
       return {
         name: 'Ozono (O₃)',
-        description: 'Gas que se forma en la atmósfera a través de reacciones químicas entre contaminantes y luz solar.',
+        description:
+          'Gas que se forma en la atmósfera a través de reacciones químicas entre contaminantes y luz solar.',
       };
     case 'no2':
       return {
         name: 'Dióxido de Nitrógeno (NO₂)',
-        description: 'Gas irritante que proviene principalmente de la quema de combustibles fósiles como carbón, petróleo y gas.',
+        description:
+          'Gas irritante que proviene principalmente de la quema de combustibles fósiles como carbón, petróleo y gas.',
       };
     case 'so2':
       return {
         name: 'Dióxido de Azufre (SO₂)',
-        description: 'Gas irritante producido por la quema de combustibles que contienen azufre, como carbón y petróleo.',
+        description:
+          'Gas irritante producido por la quema de combustibles que contienen azufre, como carbón y petróleo.',
       };
     case 'co':
       return {

--- a/src/utils/aqiDesignTokens.ts
+++ b/src/utils/aqiDesignTokens.ts
@@ -1,0 +1,308 @@
+import type { AirQualityStatus, AirQualityTheme, RecommendationInfo } from '../types';
+
+export interface AqiRangeToken {
+  min: number;
+  max: number | null;
+  status: AirQualityStatus;
+  label: string;
+}
+
+export interface AqiStatusCopy {
+  label: string;
+  shortLabel: string;
+  shareLabel: string;
+  heroLabel: string;
+  description: string;
+}
+
+export const AQI_RANGE_TOKENS: AqiRangeToken[] = [
+  {
+    min: 0,
+    max: 50,
+    status: 'good',
+    label: 'Buena',
+  },
+  {
+    min: 51,
+    max: 100,
+    status: 'moderate',
+    label: 'Moderada',
+  },
+  {
+    min: 101,
+    max: 150,
+    status: 'unhealthy-sensitive',
+    label: 'Dañina para grupos sensibles',
+  },
+  {
+    min: 151,
+    max: 200,
+    status: 'unhealthy',
+    label: 'Dañina',
+  },
+  {
+    min: 201,
+    max: 300,
+    status: 'very-unhealthy',
+    label: 'Muy dañina',
+  },
+  {
+    min: 301,
+    max: null,
+    status: 'hazardous',
+    label: 'Peligrosa',
+  },
+];
+
+export const AQI_THEME_TOKENS: Record<AirQualityStatus, AirQualityTheme> = {
+  good: {
+    primary: '#4ade80',
+    secondary: '#10b981',
+    background: '#f0fdf4',
+    text: '#166534',
+    gradient: 'from-green-400 to-emerald-500',
+  },
+  moderate: {
+    primary: '#fbbf24',
+    secondary: '#f59e0b',
+    background: '#fffbeb',
+    text: '#92400e',
+    gradient: 'from-amber-400 to-yellow-500',
+  },
+  'unhealthy-sensitive': {
+    primary: '#fb923c',
+    secondary: '#f97316',
+    background: '#fff7ed',
+    text: '#9a3412',
+    gradient: 'from-orange-400 to-orange-500',
+  },
+  unhealthy: {
+    primary: '#f87171',
+    secondary: '#ef4444',
+    background: '#fef2f2',
+    text: '#b91c1c',
+    gradient: 'from-red-400 to-red-500',
+  },
+  'very-unhealthy': {
+    primary: '#c084fc',
+    secondary: '#a855f7',
+    background: '#faf5ff',
+    text: '#7e22ce',
+    gradient: 'from-purple-400 to-purple-500',
+  },
+  hazardous: {
+    primary: '#9f1239',
+    secondary: '#881337',
+    background: '#fff1f2',
+    text: '#9f1239',
+    gradient: 'from-rose-700 to-rose-800',
+  },
+  unknown: {
+    primary: '#64748b',
+    secondary: '#475569',
+    background: '#f8fafc',
+    text: '#334155',
+    gradient: 'from-slate-400 to-slate-500',
+  },
+};
+
+export const AQI_STATUS_COPY: Record<AirQualityStatus, AqiStatusCopy> = {
+  good: {
+    label: 'Buena',
+    shortLabel: 'Buena',
+    shareLabel: 'Buena',
+    heroLabel: 'Aire limpio',
+    description:
+      'La calidad del aire es satisfactoria y representa poco o ningún riesgo para la salud.',
+  },
+  moderate: {
+    label: 'Moderada',
+    shortLabel: 'Mod.',
+    shareLabel: 'Moderada',
+    heroLabel: 'Moderada',
+    description:
+      'La calidad del aire es aceptable, pero puede haber un riesgo moderado para algunas personas sensibles.',
+  },
+  'unhealthy-sensitive': {
+    label: 'Dañina para grupos sensibles',
+    shortLabel: 'Sensibles',
+    shareLabel: 'Dañina para grupos sensibles',
+    heroLabel: 'Sensibles',
+    description:
+      'Miembros de grupos sensibles pueden experimentar efectos en la salud. El público en general no suele verse afectado.',
+  },
+  unhealthy: {
+    label: 'Dañina',
+    shortLabel: 'Dañina',
+    shareLabel: 'Dañina',
+    heroLabel: 'Dañina',
+    description:
+      'Todo el mundo puede comenzar a experimentar efectos en la salud. Las personas sensibles pueden experimentar efectos más graves.',
+  },
+  'very-unhealthy': {
+    label: 'Muy dañina',
+    shortLabel: 'Muy dañina',
+    shareLabel: 'Muy dañina',
+    heroLabel: 'Muy dañina',
+    description:
+      'Advertencias sanitarias de condiciones de emergencia. Es más probable que toda la población se vea afectada.',
+  },
+  hazardous: {
+    label: 'Peligrosa',
+    shortLabel: 'Peligrosa',
+    shareLabel: 'Peligrosa',
+    heroLabel: 'Peligrosa',
+    description:
+      'Alerta sanitaria: todos pueden experimentar efectos más graves para la salud. Se recomienda evitar cualquier actividad al aire libre.',
+  },
+  unknown: {
+    label: 'Sin lectura',
+    shortLabel: 'N/D',
+    shareLabel: 'No disponible',
+    heroLabel: 'Sin lectura',
+    description: 'No hay una lectura confiable disponible para esta ciudad en este momento.',
+  },
+};
+
+export const AQI_STATUS_SHARE_LABELS: Record<AirQualityStatus, string> = {
+  good: AQI_STATUS_COPY.good.shareLabel,
+  moderate: AQI_STATUS_COPY.moderate.shareLabel,
+  'unhealthy-sensitive': AQI_STATUS_COPY['unhealthy-sensitive'].shareLabel,
+  unhealthy: AQI_STATUS_COPY.unhealthy.shareLabel,
+  'very-unhealthy': AQI_STATUS_COPY['very-unhealthy'].shareLabel,
+  hazardous: AQI_STATUS_COPY.hazardous.shareLabel,
+  unknown: AQI_STATUS_COPY.unknown.shareLabel,
+};
+
+export const AQI_STATUS_DESCRIPTIONS: Record<AirQualityStatus, string> = {
+  good: AQI_STATUS_COPY.good.description,
+  moderate: AQI_STATUS_COPY.moderate.description,
+  'unhealthy-sensitive': AQI_STATUS_COPY['unhealthy-sensitive'].description,
+  unhealthy: AQI_STATUS_COPY.unhealthy.description,
+  'very-unhealthy': AQI_STATUS_COPY['very-unhealthy'].description,
+  hazardous: AQI_STATUS_COPY.hazardous.description,
+  unknown: AQI_STATUS_COPY.unknown.description,
+};
+
+export const AQI_RECOMMENDATIONS: Record<AirQualityStatus, RecommendationInfo[]> = {
+  good: [
+    {
+      icon: 'IoSunny',
+      title: 'Actividades al aire libre',
+      description: 'Hoy es seguro realizar actividades al aire libre, ¡disfruta del buen clima!',
+    },
+    {
+      icon: 'IoWalk',
+      title: 'Ejercicio',
+      description: 'Condiciones ideales para hacer ejercicio en exteriores.',
+    },
+    {
+      icon: 'IoHappy',
+      title: 'Calidad del aire',
+      description: 'La calidad del aire es excelente, sin riesgos para la salud.',
+    },
+  ],
+  moderate: [
+    {
+      icon: 'IoSunny',
+      title: 'Actividades al aire libre',
+      description: 'Puedes realizar actividades al aire libre, pero con moderación.',
+    },
+    {
+      icon: 'IoWalk',
+      title: 'Ejercicio',
+      description: 'Personas sensibles deben considerar reducir el ejercicio intenso al aire libre.',
+    },
+    {
+      icon: 'IoWarning',
+      title: 'Precaución',
+      description: 'Personas con condiciones respiratorias deben estar atentas a síntomas.',
+    },
+  ],
+  'unhealthy-sensitive': [
+    {
+      icon: 'IoAlert',
+      title: 'Grupos sensibles',
+      description:
+        'Niños, adultos mayores y personas con problemas respiratorios deben limitar el tiempo al aire libre.',
+    },
+    {
+      icon: 'IoWalk',
+      title: 'Ejercicio',
+      description: 'Considera realizar ejercicio en interiores o reducir la intensidad.',
+    },
+    {
+      icon: 'IoWarning',
+      title: 'Monitoreo',
+      description: 'Mantente informado sobre el nivel de contaminación a lo largo del día.',
+    },
+  ],
+  unhealthy: [
+    {
+      icon: 'IoAlert',
+      title: 'Limita exposición',
+      description: 'Evita ejercicio en exteriores y reduce actividades al aire libre.',
+    },
+    {
+      icon: 'IoHome',
+      title: 'Interior',
+      description: 'Mantén ventanas cerradas para reducir la entrada de aire contaminado.',
+    },
+    {
+      icon: 'IoMedical',
+      title: 'Salud',
+      description: 'Usa cubrebocas en exteriores, especialmente si tienes condiciones respiratorias.',
+    },
+  ],
+  'very-unhealthy': [
+    {
+      icon: 'IoWarning',
+      title: 'Evita exteriores',
+      description: 'Permanece en interiores y evita cualquier actividad física al aire libre.',
+    },
+    {
+      icon: 'IoHome',
+      title: 'En casa',
+      description: 'Mantén todas las ventanas cerradas y considera usar purificador de aire.',
+    },
+    {
+      icon: 'IoMedical',
+      title: 'Protección',
+      description: 'Usa cubrebocas N95 si debes salir, la contaminación es peligrosa.',
+    },
+  ],
+  hazardous: [
+    {
+      icon: 'IoWarning',
+      title: 'Emergencia',
+      description: 'Condiciones de emergencia sanitaria, evita completamente salir de casa.',
+    },
+    {
+      icon: 'IoHome',
+      title: 'Refugio',
+      description: 'Permanece en interiores, sella ventanas y puertas si es posible.',
+    },
+    {
+      icon: 'IoMedical',
+      title: 'Protección',
+      description: 'Si sales, usa cubrebocas N95 y limita tu tiempo de exposición al mínimo.',
+    },
+  ],
+  unknown: [
+    {
+      icon: 'IoHelpCircle',
+      title: 'Dato no disponible',
+      description: 'No hay una lectura confiable para esta ciudad en este momento.',
+    },
+    {
+      icon: 'IoRefresh',
+      title: 'Intenta actualizar',
+      description: 'Puedes refrescar la consulta o revisar otra ciudad monitoreada.',
+    },
+    {
+      icon: 'IoInformationCircle',
+      title: 'Consulta fuentes oficiales',
+      description: 'Si necesitas tomar una decisión sensible, revisa también fuentes oficiales.',
+    },
+  ],
+};


### PR DESCRIPTION
## Summary
- Add `src/utils/aqiDesignTokens.ts` as the canonical frontend source for AQI ranges, theme colors, status labels, share labels, descriptions, hero labels, and recommendations.
- Delegate `getAirQualityStatus`, `getAirQualityTheme`, `getAQIDescription`, and `getRecommendations` from `airQualityUtils.ts` to the centralized tokens.
- Reuse centralized AQI share labels in `Layout.tsx` without changing the city snapshot share behavior.

## Contract / scope
- Frontend-only UX foundation.
- No Supabase schema changes.
- No environmental DB changes.
- No RPC changes to `get_latest_air_quality_per_city`.
- No pipeline changes.
- No Core DB read model changes.
- No service role or secrets.
- No public dashboard/internal module added.

## Validation
Expected checks:
- `npm ci`
- `npm run lint`
- `npx tsc --noEmit`
- `npm run build`

Preview sanity:
- Existing AQI colors remain equivalent.
- Existing recommendations and AQI descriptions remain equivalent.
- City share copy continues to use selected city + AQI/category/pollutant when available.
- Unknown/N/D state remains explicit and does not invent AQI.
- No “AirVisual”.
- No “tiempo real”.

## Rollback
Revert this PR.