### PR TITLE
fix: harden unknown air quality states

### DIFF
--- a/src/components/AirQualityCard.tsx
+++ b/src/components/AirQualityCard.tsx
@@ -26,6 +26,12 @@ import {
   AQI_STATUS_COPY,
   AQI_THEME_TOKENS,
 } from '../utils/aqiDesignTokens';
+import {
+  formatNullableNumber,
+  formatNullableTimestamp,
+  getUnknownStateCopy,
+  hasReliableAqi,
+} from '../utils/airQualityDisplay';
 import { useAirQuality } from '../context/AirQualityContext';
 
 interface AirQualityCardProps {
@@ -110,31 +116,6 @@ const STATUS_CLASSES: Record<
   },
 };
 
-function formatNullableMetric(value: number | null | undefined, suffix: string) {
-  if (value === null || value === undefined) {
-    return 'N/D';
-  }
-
-  return `${value}${suffix}`;
-}
-
-function formatMeasurementDateTime(timestamp: string | null | undefined) {
-  if (!timestamp) {
-    return 'N/D';
-  }
-
-  const parsedDate = new Date(timestamp);
-
-  if (Number.isNaN(parsedDate.getTime())) {
-    return 'N/D';
-  }
-
-  return parsedDate.toLocaleString('es-MX', {
-    dateStyle: 'medium',
-    timeStyle: 'short',
-  });
-}
-
 function getStatusIcon(status: AirQualityStatus, className: string) {
   switch (status) {
     case 'good':
@@ -176,16 +157,17 @@ export default function AirQualityCard({ data, className = '' }: AirQualityCardP
     setHasMounted(true);
   }, []);
 
-  const status = data.status || 'unknown';
-  const copy = AQI_STATUS_COPY[status];
+  const reliableAqi = hasReliableAqi(data);
+  const status = reliableAqi ? data.status : 'unknown';
+  const copy = reliableAqi ? AQI_STATUS_COPY[status] : getUnknownStateCopy();
   const theme = AQI_THEME_TOKENS[status];
   const classes = STATUS_CLASSES[status];
   const isUnknown = status === 'unknown';
-  const aqiLabel = isUnknown ? AQI_STATUS_COPY.unknown.shortLabel : data.aqi;
+  const aqiLabel = reliableAqi ? formatNullableNumber(data.aqi) : AQI_STATUS_COPY.unknown.shortLabel;
   const mainPollutantLabel = data.main_pollutant_us
     ? getPollutantInfo(data.main_pollutant_us).name
     : 'N/D';
-  const measurementTime = isUnknown ? 'N/D' : formatMeasurementDateTime(data.timestamp);
+  const measurementTime = reliableAqi ? formatNullableTimestamp(data.timestamp) : 'N/D';
 
   return (
     <motion.section
@@ -305,7 +287,7 @@ export default function AirQualityCard({ data, className = '' }: AirQualityCardP
               <div className="mx-3 mb-2 grid grid-cols-2 overflow-hidden rounded-xl border border-slate-200 dark:border-slate-700 sm:mx-4 sm:mb-4 sm:rounded-2xl">
                 <DetailItem
                   label="Temperatura"
-                  value={formatNullableMetric(data.temperature, ' °C')}
+                  value={formatNullableNumber(data.temperature, ' °C', 1)}
                   accentClass={classes.accent}
                   softBgClass={classes.softBg}
                   weatherIcon={data.weather_icon}
@@ -313,7 +295,7 @@ export default function AirQualityCard({ data, className = '' }: AirQualityCardP
                 />
                 <DetailItem
                   label="Humedad"
-                  value={formatNullableMetric(data.humidity, ' %')}
+                  value={formatNullableNumber(data.humidity, ' %')}
                   accentClass="text-blue-600"
                   softBgClass="bg-blue-50"
                   useHumidityIcon={true}
@@ -321,7 +303,7 @@ export default function AirQualityCard({ data, className = '' }: AirQualityCardP
                 />
                 <DetailItem
                   label="Viento"
-                  value={formatNullableMetric(data.wind?.speed, ' km/h')}
+                  value={formatNullableNumber(data.wind?.speed, ' km/h', 1)}
                   accentClass="text-blue-600"
                   softBgClass="bg-blue-50"
                   useWindIcon={true}

--- a/src/components/AirQualityMap.tsx
+++ b/src/components/AirQualityMap.tsx
@@ -6,6 +6,7 @@ import { useAirQuality } from '../context/AirQualityContext';
 import { AirQualityStatus, CityAirQualityData, CitySelectorOption } from '../types';
 import { getAirQualityStatus, getAirQualityTheme } from '../utils/airQualityUtils';
 import { AQI_STATUS_COPY } from '../utils/aqiDesignTokens';
+import { formatNullableNumber, formatNullableTimestamp, hasReliableAqi, isFiniteNumber } from '../utils/airQualityDisplay';
 
 const MONTERREY_METRO_CENTER: [number, number] = [25.6866, -100.3161];
 const MONTERREY_METRO_ZOOM = 10;
@@ -39,25 +40,9 @@ function hasValidCoordinates(row: CityAirQualityData) {
   );
 }
 
-function formatTime(timestamp: string | null | undefined) {
-  if (!timestamp) {
-    return 'N/D';
-  }
-
-  const parsedDate = new Date(timestamp);
-
-  if (Number.isNaN(parsedDate.getTime())) {
-    return 'N/D';
-  }
-
-  return parsedDate.toLocaleString('es-MX', {
-    timeStyle: 'short',
-  });
-}
-
 function getPollutantLabel(pollutant: string | null) {
   if (!pollutant) {
-    return 'No disponible';
+    return 'N/D';
   }
 
   const normalizedPollutant = pollutant.toLowerCase();
@@ -83,11 +68,13 @@ function getPollutantLabel(pollutant: string | null) {
 }
 
 function getMarkerRadius(row: CityAirQualityData) {
-  if (row.aqi_us === null) {
+  const aqi = row.aqi_us;
+
+  if (!isFiniteNumber(aqi)) {
     return 11;
   }
 
-  return row.aqi_us > 150 ? 15 : 12;
+  return aqi > 150 ? 15 : 12;
 }
 
 function getCityOption(row: CityAirQualityData, cityOptions: CitySelectorOption[]) {
@@ -98,6 +85,9 @@ function getCityOption(row: CityAirQualityData, cityOptions: CitySelectorOption[
     name: row.city_name,
     latitude: row.latitude ?? MONTERREY_METRO_CENTER[0],
     longitude: row.longitude ?? MONTERREY_METRO_CENTER[1],
+    availability: hasReliableAqi(row.aqi_us) ? 'available' : 'invalid-aqi',
+    disabledReason: hasReliableAqi(row.aqi_us) ? undefined : 'Ultima lectura no disponible',
+    readingTimestamp: row.reading_timestamp,
   };
 }
 
@@ -186,6 +176,7 @@ export default function AirQualityMap() {
             const theme = getAirQualityTheme(status);
             const isSelected = selectedCity.city_id === row.city_id;
             const cityOption = getCityOption(row, cityOptions);
+            const aqiLabel = hasReliableAqi(row.aqi_us) ? formatNullableNumber(row.aqi_us) : 'N/D';
 
             return (
               <CircleMarker
@@ -207,12 +198,12 @@ export default function AirQualityMap() {
                   <div className="max-w-[170px] text-xs text-slate-800">
                     <p className="text-sm font-semibold leading-tight">{row.city_name}</p>
                     <p className="mt-1 font-semibold">
-                      AQI {row.aqi_us ?? 'N/D'} - {STATUS_LABELS[status]}
+                      AQI {aqiLabel} - {STATUS_LABELS[status]}
                     </p>
                     <p className="mt-1">{getPollutantLabel(row.main_pollutant_us)}</p>
                     <p className="mt-1 text-slate-600">
-                      Medicion {formatTime(row.reading_timestamp)} - Act.{' '}
-                      {formatTime(row.last_successful_update_at)}
+                      Medicion {formatNullableTimestamp(row.reading_timestamp, { timeStyle: 'short' })} - Act.{' '}
+                      {formatNullableTimestamp(row.last_successful_update_at, { timeStyle: 'short' })}
                     </p>
                   </div>
                 </Popup>
@@ -232,7 +223,7 @@ export default function AirQualityMap() {
               className="rounded-lg border px-2.5 py-1 text-base font-bold sm:text-lg"
               style={{ borderColor: selectedTheme.primary, color: selectedTheme.text }}
             >
-              AQI {selectedRow.aqi_us ?? 'N/D'}
+              AQI {hasReliableAqi(selectedRow.aqi_us) ? formatNullableNumber(selectedRow.aqi_us) : 'N/D'}
             </span>
             <span
               className="rounded-lg border px-2.5 py-1 text-sm font-semibold"
@@ -252,13 +243,13 @@ export default function AirQualityMap() {
             <div>
               <dt className="text-gray-500 dark:text-gray-400">Medicion</dt>
               <dd className="font-semibold text-gray-900 dark:text-white">
-                {formatTime(selectedRow.reading_timestamp)}
+                {formatNullableTimestamp(selectedRow.reading_timestamp, { timeStyle: 'short' })}
               </dd>
             </div>
             <div>
               <dt className="text-gray-500 dark:text-gray-400">Actualizado</dt>
               <dd className="font-semibold text-gray-900 dark:text-white">
-                {formatTime(selectedRow.last_successful_update_at)}
+                {formatNullableTimestamp(selectedRow.last_successful_update_at, { timeStyle: 'short' })}
               </dd>
             </div>
             <div>

--- a/src/components/CityHistoricalTrend.tsx
+++ b/src/components/CityHistoricalTrend.tsx
@@ -23,6 +23,7 @@ import {
 } from '../services/apiService';
 import { useAirQuality } from '../context/AirQualityContext';
 import { AQI_THEME_TOKENS } from '../utils/aqiDesignTokens';
+import { formatNullableTimestamp, isFiniteNumber } from '../utils/airQualityDisplay';
 
 interface CityHistoricalTrendProps {
   cityId: number;
@@ -136,7 +137,7 @@ function toChartPoint(
 ): ChartPoint | null {
   const metricValue = getMetricValue(row, metric);
 
-  if (metricValue === null) {
+  if (!isFiniteNumber(metricValue)) {
     return null;
   }
 
@@ -356,7 +357,7 @@ export default function CityHistoricalTrend({ cityId, cityName }: CityHistorical
                 labelFormatter={(_, payload) => {
                   const point = payload?.[0]?.payload as ChartPoint | undefined;
                   return point
-                    ? new Date(point.timestamp).toLocaleString('es-MX', {
+                    ? formatNullableTimestamp(point.timestamp, {
                         dateStyle: 'medium',
                         timeStyle: range === '6m' ? undefined : 'short',
                       })

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -8,6 +8,7 @@ import { IoHomeOutline, IoInformationCircleOutline, IoLayersOutline, IoLinkOutli
 import { Metadata } from './seo/Metadata';
 import { Analytics } from './seo/Analytics';
 import { getCitySlug } from '../utils/cityRoutingUtils';
+import { formatNullableTimestamp, hasReliableAqi } from '../utils/airQualityDisplay';
 import { CityShareMethod, submitCityShareSignal } from '../services/coreSignalService';
 import type { AirQualityData, AirQualityStatus } from '../types';
 
@@ -20,7 +21,7 @@ const SOCIAL_PREVIEW_TITLE = 'MonterreyRespira - Calidad del aire en la Zona Met
 const SOCIAL_PREVIEW_DESCRIPTION = 'Consulta AQI, contaminante principal y recomendaciones por municipio.';
 
 const hasShareableAqi = (aqi: number | null | undefined, status: AirQualityStatus): aqi is number => {
-  return status !== 'unknown' && typeof aqi === 'number' && Number.isFinite(aqi);
+  return status !== 'unknown' && hasReliableAqi(aqi);
 };
 
 const formatMainPollutantForShare = (pollutant: string | null | undefined): string | null => {
@@ -59,13 +60,17 @@ export default function Layout({ children }: LayoutProps) {
   const shareDescription = buildCitySnapshotShareDescription(currentCity, airQualityData);
 
   const submitShareSignal = (shareMethod: CityShareMethod) => {
+    const shareableAqi = airQualityData && hasReliableAqi(airQualityData)
+      ? airQualityData.aqi
+      : null;
+
     void submitCityShareSignal({
       cityId: selectedCity.city_id,
       cityName: selectedCity.name,
       citySlug: getCitySlug(selectedCity),
       route: window.location.pathname,
       shareMethod,
-      aqiUs: airQualityData?.aqi ?? null,
+      aqiUs: shareableAqi,
       measurementFreshness: airQualityData?.measurementFreshness ?? 'unknown',
     }).catch((error: unknown) => {
       console.warn(CITY_SHARE_SIGNAL_FAILED_MESSAGE, error);
@@ -109,6 +114,7 @@ export default function Layout({ children }: LayoutProps) {
       case '#f87171': return 'bg-red-100 text-red-800';
       case '#c084fc': return 'bg-purple-100 text-purple-800';
       case '#9f1239': return 'bg-rose-100 text-rose-800';
+      case '#64748b': return 'bg-slate-100 text-slate-800';
       default: return 'bg-blue-100 text-blue-800';
     }
   };
@@ -124,6 +130,7 @@ export default function Layout({ children }: LayoutProps) {
       case '#f87171': return 'text-red-600';
       case '#c084fc': return 'text-purple-600';
       case '#9f1239': return 'text-rose-600';
+      case '#64748b': return 'text-slate-600';
       default: return 'text-blue-600';
     }
   };
@@ -234,7 +241,7 @@ export default function Layout({ children }: LayoutProps) {
                     Medicion:
                   </span>
                   <span className="ml-1 text-xs sm:text-sm">
-                    {new Date(airQualityData.timestamp).toLocaleTimeString('es-MX', {
+                    {formatNullableTimestamp(airQualityData.timestamp, {
                       hour: '2-digit',
                       minute: '2-digit',
                       hour12: true

--- a/src/components/PollutantsChart.tsx
+++ b/src/components/PollutantsChart.tsx
@@ -12,6 +12,7 @@ import {
 } from 'recharts';
 import { AirQualityData } from '../types';
 import { getPollutantInfo } from '../utils/airQualityUtils';
+import { isFiniteNumber } from '../utils/airQualityDisplay';
 import { motion } from 'framer-motion';
 import { IoInformationCircleOutline } from 'react-icons/io5';
 
@@ -72,14 +73,14 @@ export default function PollutantsChart({ data, className = '' }: PollutantsChar
     { name: 'o3', value: data.o3, fill: '#60a5fa', fullName: 'Ozono' },      // blue
     { name: 'no2', value: data.no2, fill: '#fbbf24', fullName: 'NO₂' },    // yellow
     { name: 'so2', value: data.so2, fill: '#a78bfa', fullName: 'SO₂' },    // purple
-    { name: 'co', value: data.co / 10, fill: '#4ade80', fullName: 'CO' }, // green (scaled down for visualization)
-  ];
+    { name: 'co', value: isFiniteNumber(data.co) ? data.co / 10 : null, fill: '#4ade80', fullName: 'CO' }, // green (scaled down for visualization)
+  ].filter((pollutant): pollutant is typeof pollutant & { value: number } => isFiniteNumber(pollutant.value));
 
   const getBarBackground = (index: number) => {
     return activeIndex === index ? 'rgba(255, 255, 255, 0.2)' : 'rgba(255, 255, 255, 0)';
   };
 
-  const handleBarClick = (data: any, index: number) => {
+  const handleBarClick = (_data: unknown, index: number) => {
     setActiveIndex(index === activeIndex ? null : index);
   };
 

--- a/src/context/AirQualityContext.tsx
+++ b/src/context/AirQualityContext.tsx
@@ -19,6 +19,7 @@ import {
   writeStoredCityId,
   findCityById,
 } from '../utils/cityRoutingUtils';
+import { hasReliableAqi } from '../utils/airQualityDisplay';
 
 type CityOption = (typeof MONTERREY_LOCATIONS_WITH_COORDS)[number];
 
@@ -74,24 +75,24 @@ function getRpcFailureReason(error: unknown): string {
 
 function buildDegradedAirQualityData(city: CityOption, reason: string): AirQualityData {
   return {
-    aqi: 0,
+    aqi: null,
     status: 'unknown',
     dataQuality: 'degraded',
     degradationReason: reason,
     measurementFreshness: 'unknown',
-    pm25: 0,
-    pm10: 0,
-    o3: 0,
-    no2: 0,
-    so2: 0,
-    co: 0,
-    temperature: 0,
-    humidity: 0,
+    pm25: null,
+    pm10: null,
+    o3: null,
+    no2: null,
+    so2: null,
+    co: null,
+    temperature: null,
+    humidity: null,
     wind: {
-      speed: 0,
-      direction: 0,
+      speed: null,
+      direction: null,
     },
-    timestamp: new Date().toISOString(),
+    timestamp: null,
     last_successful_update_at: null,
     location: {
       name: city.name,
@@ -152,7 +153,7 @@ function getCityAvailability(row: CityAirQualityData | undefined): CityDataAvail
     return 'missing';
   }
 
-  return row.aqi_us === null ? 'invalid-aqi' : 'available';
+  return hasReliableAqi(row.aqi_us) ? 'available' : 'invalid-aqi';
 }
 
 function getCityDisabledReason(availability: CityDataAvailability): string | undefined {
@@ -199,7 +200,7 @@ function transformApiResponse(
     );
   }
 
-  if (cityData.aqi_us === null) {
+  if (!hasReliableAqi(cityData.aqi_us)) {
     return buildDegradedAirQualityData(
       city,
       `Última lectura no disponible para ${city.name}.`,
@@ -218,17 +219,17 @@ function transformApiResponse(
     dataQuality: measurementFreshness === 'fresh' ? 'fresh' : 'degraded',
     degradationReason: measurementFreshnessReason,
     measurementFreshness,
-    pm25: 0,
-    pm10: 0,
-    o3: 0,
-    no2: 0,
-    so2: 0,
-    co: 0,
-    temperature: cityData.temperature_c ?? 0,
-    humidity: cityData.humidity_percent ?? 0,
+    pm25: null,
+    pm10: null,
+    o3: null,
+    no2: null,
+    so2: null,
+    co: null,
+    temperature: cityData.temperature_c,
+    humidity: cityData.humidity_percent,
     wind: {
-      speed: cityData.wind_speed_ms ?? 0,
-      direction: cityData.wind_direction_deg ?? 0,
+      speed: cityData.wind_speed_ms,
+      direction: cityData.wind_direction_deg,
     },
     timestamp: cityData.reading_timestamp,
     last_successful_update_at: cityData.last_successful_update_at,

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -8,6 +8,7 @@ import Recommendations from '../components/Recommendations';
 import CitySelector from '../components/CitySelector';
 import AirQualityMap from '../components/AirQualityMap';
 import CityHistoricalTrend from '../components/CityHistoricalTrend';
+import { hasReliableAqi } from '../utils/airQualityDisplay';
 
 export default function Dashboard() {
   const {
@@ -31,6 +32,7 @@ export default function Dashboard() {
       case '#f87171': return 'bg-red-500 hover:bg-red-600 text-white';
       case '#c084fc': return 'bg-purple-500 hover:bg-purple-600 text-white';
       case '#9f1239': return 'bg-rose-600 hover:bg-rose-700 text-white';
+      case '#64748b': return 'bg-slate-500 hover:bg-slate-600 text-white';
       default: return 'bg-blue-500 hover:bg-blue-600 text-white';
     }
   };
@@ -45,6 +47,7 @@ export default function Dashboard() {
       case '#f87171': return 'border-red-500';
       case '#c084fc': return 'border-purple-500';
       case '#9f1239': return 'border-rose-600';
+      case '#64748b': return 'border-slate-500';
       default: return 'border-blue-500';
     }
   };
@@ -139,7 +142,7 @@ export default function Dashboard() {
         <div className="flex flex-col gap-2 lg:col-span-2 lg:gap-6">
           <AirQualityCard data={airQualityData} />
           <CityHistoricalTrend cityId={selectedCity.city_id} cityName={selectedCity.name} />
-          <Recommendations status={airQualityData.status} />
+          <Recommendations status={hasReliableAqi(airQualityData) ? airQualityData.status : 'unknown'} />
           <div className="lg:hidden">
             <AirQualityMap />
           </div>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -58,25 +58,25 @@ export interface CitySelectorOption {
 }
 
 export interface AirQualityData {
-  aqi: number;
+  aqi: number | null;
   status: AirQualityStatus;
   dataQuality: AirQualityDataQuality;
   degradationReason?: string;
   measurementFreshness: MeasurementFreshness;
-  pm25: number;
-  pm10: number;
-  o3: number;
-  no2: number;
-  so2: number;
-  co: number;
+  pm25: number | null;
+  pm10: number | null;
+  o3: number | null;
+  no2: number | null;
+  so2: number | null;
+  co: number | null;
   iaqi?: Partial<Record<'pm25' | 'pm10' | 'o3' | 'no2' | 'so2' | 'co', { v: number }>>;
-  temperature: number;
-  humidity: number;
+  temperature: number | null;
+  humidity: number | null;
   wind: {
-    speed: number;
-    direction: number;
+    speed: number | null;
+    direction: number | null;
   };
-  timestamp: string;
+  timestamp: string | null;
   last_successful_update_at?: string | null;
   location: {
     name: string;

--- a/src/utils/airQualityDisplay.ts
+++ b/src/utils/airQualityDisplay.ts
@@ -1,0 +1,50 @@
+import type { AirQualityData } from '../types';
+import { AQI_STATUS_COPY } from './aqiDesignTokens';
+
+export const NOT_AVAILABLE_LABEL = 'N/D';
+
+export function isFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+export function hasReliableAqi(value: AirQualityData | number | null | undefined): boolean {
+  const aqi = typeof value === 'object' && value !== null ? value.aqi : value;
+
+  return isFiniteNumber(aqi) && aqi >= 0;
+}
+
+export function formatNullableNumber(
+  value: number | null | undefined,
+  suffix = '',
+  maximumFractionDigits = 0,
+): string {
+  if (!isFiniteNumber(value)) {
+    return NOT_AVAILABLE_LABEL;
+  }
+
+  return `${new Intl.NumberFormat('es-MX', {
+    maximumFractionDigits,
+  }).format(value)}${suffix}`;
+}
+
+export function formatNullableTimestamp(
+  timestamp: string | null | undefined,
+  options: Intl.DateTimeFormatOptions = { dateStyle: 'medium', timeStyle: 'short' },
+): string {
+  if (!timestamp) {
+    return NOT_AVAILABLE_LABEL;
+  }
+
+  const parsedDate = new Date(timestamp);
+
+  if (Number.isNaN(parsedDate.getTime())) {
+    return NOT_AVAILABLE_LABEL;
+  }
+
+  return parsedDate.toLocaleString('es-MX', options);
+}
+
+export function getUnknownStateCopy() {
+  return AQI_STATUS_COPY.unknown;
+}
+

--- a/src/utils/aqiDesignTokens.ts
+++ b/src/utils/aqiDesignTokens.ts
@@ -159,7 +159,7 @@ export const AQI_STATUS_COPY: Record<AirQualityStatus, AqiStatusCopy> = {
     label: 'Sin lectura',
     shortLabel: 'N/D',
     shareLabel: 'No disponible',
-    heroLabel: 'Sin lectura',
+    heroLabel: 'Sin lectura disponible',
     description: 'No hay una lectura confiable disponible para esta ciudad en este momento.',
   },
 };


### PR DESCRIPTION
## Summary
- Add shared display helpers for nullable AQI, numbers, timestamps, and unknown-state copy.
- Stop fabricating AQI, weather, pollutant, or timestamp values when RPC rows are missing or incomplete.
- Harden public card, trend, map, layout share/header, and nullable pollutant chart handling.

## Validation
- npm run lint
- npm run typecheck
- npm run build
- Playwright MCP mobile 390x844 missing AQI/pollutant/timestamps: Sin lectura disponible, N/D fields, no invalid date, no AirVisual/tiempo real UI copy.
- Playwright MCP mobile 390x844 normal AQI 42 row: AQI/status/pollutant/weather fields still render and no horizontal overflow.

## Rollback
- Revert this PR.