### PR TITLE
feat: upgrade mobile AQI hero card

### DIFF
--- a/src/components/AirQualityCard.tsx
+++ b/src/components/AirQualityCard.tsx
@@ -49,6 +49,7 @@ const STATUS_CLASSES: Record<
     ring: string;
     chip: string;
     chart: string;
+    heroOverlay: string;
   }
 > = {
   good: {
@@ -59,6 +60,7 @@ const STATUS_CLASSES: Record<
     ring: 'ring-emerald-200',
     chip: 'bg-emerald-700/80',
     chart: 'text-emerald-600',
+    heroOverlay: 'from-emerald-500/95 via-emerald-500/82 to-teal-500/18',
   },
   moderate: {
     gradient: 'from-amber-400 via-yellow-500 to-orange-400',
@@ -68,6 +70,7 @@ const STATUS_CLASSES: Record<
     ring: 'ring-amber-200',
     chip: 'bg-amber-700/70',
     chart: 'text-amber-600',
+    heroOverlay: 'from-amber-400/95 via-yellow-500/82 to-orange-300/18',
   },
   'unhealthy-sensitive': {
     gradient: 'from-orange-500 via-orange-500 to-amber-500',
@@ -77,6 +80,7 @@ const STATUS_CLASSES: Record<
     ring: 'ring-orange-200',
     chip: 'bg-orange-700/75',
     chart: 'text-orange-600',
+    heroOverlay: 'from-orange-500/95 via-orange-500/82 to-amber-400/18',
   },
   unhealthy: {
     gradient: 'from-rose-600 via-red-500 to-orange-500',
@@ -86,6 +90,7 @@ const STATUS_CLASSES: Record<
     ring: 'ring-rose-200',
     chip: 'bg-rose-900/65',
     chart: 'text-rose-600',
+    heroOverlay: 'from-rose-600/95 via-red-500/82 to-orange-500/18',
   },
   'very-unhealthy': {
     gradient: 'from-purple-700 via-fuchsia-600 to-purple-500',
@@ -95,6 +100,7 @@ const STATUS_CLASSES: Record<
     ring: 'ring-purple-200',
     chip: 'bg-purple-950/60',
     chart: 'text-purple-600',
+    heroOverlay: 'from-purple-700/95 via-fuchsia-600/82 to-purple-500/18',
   },
   hazardous: {
     gradient: 'from-rose-950 via-rose-800 to-red-700',
@@ -104,6 +110,7 @@ const STATUS_CLASSES: Record<
     ring: 'ring-rose-300',
     chip: 'bg-black/35',
     chart: 'text-rose-800',
+    heroOverlay: 'from-rose-950/95 via-rose-800/86 to-red-700/20',
   },
   unknown: {
     gradient: 'from-slate-600 via-slate-500 to-slate-400',
@@ -113,6 +120,7 @@ const STATUS_CLASSES: Record<
     ring: 'ring-slate-200',
     chip: 'bg-slate-800/45',
     chart: 'text-slate-600',
+    heroOverlay: 'from-slate-700/95 via-slate-600/84 to-slate-400/22',
   },
 };
 
@@ -176,25 +184,19 @@ export default function AirQualityCard({ data, className = '' }: AirQualityCardP
       aria-label={`Calidad del aire en ${data.location.name}: ${copy.label}`}
     >
       <div
-        className={`relative h-[12.25rem] overflow-hidden rounded-[1.15rem] bg-gradient-to-br ${classes.gradient} px-4 py-3 text-white shadow-[0_12px_26px_rgba(15,23,42,0.14)] ring-1 ${classes.ring} sm:h-auto sm:rounded-[1.35rem] sm:px-8 sm:py-6`}
+        className={`relative min-h-[26.25rem] overflow-hidden rounded-[1.35rem] bg-gradient-to-br ${classes.gradient} px-5 py-5 text-white shadow-[0_16px_34px_rgba(15,23,42,0.18)] ring-1 ${classes.ring} sm:min-h-[25rem] sm:rounded-[1.6rem] sm:px-8 sm:py-7`}
       >
         <div
-          className="absolute inset-0 bg-[url('/images/monterrey-cerro-silla.jpg')] bg-cover bg-[78%_100%] opacity-95"
+          className="absolute inset-0 bg-[url('/images/monterrey-cerro-silla.jpg')] bg-cover bg-[70%_100%] opacity-95"
           aria-hidden="true"
         />
-        <div
-          className="absolute inset-0"
-          style={{
-            background: `linear-gradient(100deg, ${theme.primary} 0%, ${theme.primary}f7 36%, ${theme.primary}d9 51%, ${theme.secondary}55 68%, transparent 100%)`,
-          }}
-          aria-hidden="true"
-        />
-        <div className="absolute inset-0 bg-gradient-to-r from-black/10 via-transparent to-white/10" />
+        <div className={`absolute inset-0 bg-gradient-to-r ${classes.heroOverlay}`} aria-hidden="true" />
+        <div className="absolute inset-0 bg-gradient-to-t from-black/15 via-transparent to-white/18" aria-hidden="true" />
 
         <div className="relative z-10">
-          <div className="mb-1.5 flex items-start justify-between gap-3">
-            <div>
-              <p className="text-[1.18rem] font-semibold leading-none tracking-normal sm:text-3xl sm:font-bold">
+          <div className="mb-3 flex items-start justify-between gap-3">
+            <div className="min-w-0">
+              <p className="truncate text-[1.42rem] font-black leading-tight tracking-normal sm:text-4xl">
                 {data.location.name}
               </p>
             </div>
@@ -203,51 +205,51 @@ export default function AirQualityCard({ data, className = '' }: AirQualityCardP
               whileTap={{ scale: 0.96 }}
               whileHover={{ scale: 1.02 }}
               onClick={() => refreshData()}
-              className="absolute right-0 top-0 hidden rounded-full bg-white/12 p-1.5 text-white/90 shadow-sm backdrop-blur-md transition hover:bg-white/20 sm:block"
+              className="rounded-full bg-white/16 p-2 text-white/95 shadow-sm backdrop-blur-md transition hover:bg-white/25"
               aria-label="Refrescar datos"
               type="button"
             >
-              <IoRefreshOutline className="h-4 w-4" />
+              <IoRefreshOutline className="h-5 w-5" />
             </motion.button>
           </div>
 
-          <div className="flex items-center justify-between gap-2">
-            <div className="flex min-w-0 items-end gap-2">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div className="flex min-w-0 items-end gap-3">
               <motion.div
                 key={String(aqiLabel)}
                 initial={hasMounted ? { opacity: 0, scale: 0.95 } : false}
                 animate={{ opacity: 1, scale: 1 }}
                 transition={{ duration: 0.25 }}
-                className="text-[3.55rem] font-black leading-[0.82] tracking-normal text-white drop-shadow-lg sm:text-8xl"
+                className="text-[5.85rem] font-black leading-[0.78] tracking-normal text-white drop-shadow-xl sm:text-9xl"
               >
                 {aqiLabel}
               </motion.div>
-              <div className="mb-1 text-[1.05rem] font-medium leading-tight text-white/95 sm:text-2xl">
+              <div className="mb-2 text-[1.45rem] font-medium leading-tight text-white/95 sm:text-3xl">
                 <span className="block">AQI</span>
                 <span className="block">US</span>
               </div>
             </div>
 
             <div
-              className={`flex shrink-0 items-center gap-1.5 rounded-full ${classes.chip} px-2.5 py-2 text-white shadow-lg backdrop-blur-md sm:px-4 sm:py-3`}
+              className={`flex shrink-0 items-center gap-2 rounded-full ${classes.chip} px-4 py-3 text-white shadow-lg backdrop-blur-md sm:px-5 sm:py-4`}
               style={{ backgroundColor: isUnknown ? undefined : `${theme.secondary}cc` }}
             >
-              {getStatusIcon(status, 'h-[1.1rem] w-[1.1rem] shrink-0 sm:h-7 sm:w-7')}
-              <span className="whitespace-nowrap text-[0.84rem] font-semibold sm:text-lg sm:font-black">{copy.heroLabel}</span>
+              {getStatusIcon(status, 'h-7 w-7 shrink-0 sm:h-9 sm:w-9')}
+              <span className="whitespace-nowrap text-[1.08rem] font-black sm:text-2xl">{copy.heroLabel}</span>
             </div>
           </div>
 
-          <p className="mt-1 text-[0.76rem] font-medium leading-tight text-white/95 sm:text-base sm:font-semibold">
+          <p className="mt-5 text-[1rem] font-semibold leading-tight text-white/95 sm:text-xl">
             Contaminante principal: <span className="font-semibold sm:font-black">{mainPollutantLabel}</span>
           </p>
 
-          <p className="mt-1 max-w-[28rem] text-[0.72rem] font-normal leading-snug text-white sm:text-xl sm:font-medium">
+          <p className="mt-3 max-w-[34rem] text-[0.98rem] font-medium leading-snug text-white sm:text-xl">
             {copy.description}
           </p>
 
-          <div className="mt-1.5 max-w-sm">
+          <div className="mt-4 max-w-[16.5rem]">
             <InfoPill
-              icon={<IoTimeOutline className={`h-6 w-6 ${classes.accent}`} />}
+              icon={<IoTimeOutline className="h-6 w-6" />}
               label={getFreshnessLabel(data)}
               value={measurementTime}
             />
@@ -260,13 +262,13 @@ export default function AirQualityCard({ data, className = '' }: AirQualityCardP
       >
         <button
           onClick={() => setShowDetails(!showDetails)}
-          className="flex w-full items-center justify-between px-4 py-1 text-left hover:bg-slate-50 dark:hover:bg-slate-700/30 sm:px-5 sm:py-4"
+          className="flex w-full items-center justify-between px-5 py-4 text-left hover:bg-slate-50 dark:hover:bg-slate-700/30 sm:px-6 sm:py-5"
           type="button"
           aria-expanded={showDetails}
         >
           <span className="flex items-center gap-3">
-            <IoLeafOutline className={`h-[1.125rem] w-[1.125rem] ${classes.chart} sm:h-7 sm:w-7`} />
-            <span className="text-[0.96rem] font-semibold text-slate-950 dark:text-white sm:text-xl sm:font-black">
+            <IoLeafOutline className={`h-7 w-7 ${classes.chart} sm:h-8 sm:w-8`} />
+            <span className="text-[1.2rem] font-black text-slate-950 dark:text-white sm:text-2xl">
               Detalles ambientales
             </span>
           </span>
@@ -284,7 +286,7 @@ export default function AirQualityCard({ data, className = '' }: AirQualityCardP
               transition={{ duration: 0.25 }}
               className="overflow-hidden"
             >
-              <div className="mx-3 mb-2 grid grid-cols-2 overflow-hidden rounded-xl border border-slate-200 dark:border-slate-700 sm:mx-4 sm:mb-4 sm:rounded-2xl">
+              <div className="mx-4 mb-4 grid grid-cols-2 overflow-hidden rounded-2xl border border-slate-200 dark:border-slate-700 sm:mx-5 sm:mb-5">
                 <DetailItem
                   label="Temperatura"
                   value={formatNullableNumber(data.temperature, ' °C', 1)}
@@ -344,11 +346,11 @@ interface InfoPillProps {
 
 function InfoPill({ icon, label, value }: InfoPillProps) {
   return (
-    <div className="flex min-w-0 items-center gap-2 rounded-lg bg-white/95 px-2.5 py-1.5 text-slate-950 shadow-sm backdrop-blur-md sm:rounded-xl sm:px-4 sm:py-3">
-      <span className="shrink-0 [&>svg]:h-[1.125rem] [&>svg]:w-[1.125rem] sm:[&>svg]:h-6 sm:[&>svg]:w-6">{icon}</span>
+    <div className="flex min-w-0 items-center gap-3 rounded-xl bg-white/95 px-3 py-2.5 text-slate-950 shadow-md backdrop-blur-md sm:rounded-2xl sm:px-4 sm:py-3">
+      <span className="shrink-0 text-amber-500 [&>svg]:h-7 [&>svg]:w-7 sm:[&>svg]:h-8 sm:[&>svg]:w-8">{icon}</span>
       <span className="min-w-0">
-        <span className="block truncate text-[0.68rem] font-medium text-slate-500 sm:text-sm">{label}</span>
-        <span className="block truncate text-[0.78rem] font-semibold sm:text-base sm:font-black">{value}</span>
+        <span className="block truncate text-[0.78rem] font-semibold text-slate-500 sm:text-sm">{label}</span>
+        <span className="block text-[0.9rem] font-black leading-tight sm:text-lg">{value}</span>
       </span>
     </div>
   );
@@ -389,11 +391,11 @@ function DetailItem({
 
   const iconNode = (() => {
     if (useWeatherIconAsMainIcon && weatherIcon) {
-      return <img src={getWeatherIconUrl(weatherIcon)} alt="Clima" className="h-[1.125rem] w-[1.125rem] sm:h-9 sm:w-9" />;
+      return <img src={getWeatherIconUrl(weatherIcon)} alt="Clima" className="h-8 w-8 sm:h-10 sm:w-10" />;
     }
 
     if (useHumidityIcon && humidityValue !== null && humidityValue !== undefined) {
-      return <img src={getHumidityIcon(humidityValue)} alt="Humedad" className="h-[1.125rem] w-[1.125rem] sm:h-9 sm:w-9" />;
+      return <img src={getHumidityIcon(humidityValue)} alt="Humedad" className="h-8 w-8 sm:h-10 sm:w-10" />;
     }
 
     if (
@@ -408,27 +410,27 @@ function DetailItem({
         <img
           src={windIcon.icon}
           alt="Viento"
-          className="h-[1.125rem] w-[1.125rem] sm:h-9 sm:w-9"
+          className="h-8 w-8 sm:h-10 sm:w-10"
           style={{ transform: `rotate(${windIcon.rotation}deg)` }}
         />
       );
     }
 
     if (useMainPollutantIcon) {
-      return <img src={getMainPollutantIcon()} alt="Contaminante" className="h-[1.125rem] w-[1.125rem] sm:h-9 sm:w-9" />;
+      return <img src={getMainPollutantIcon()} alt="Contaminante" className="h-8 w-8 sm:h-10 sm:w-10" />;
     }
 
     return <IoCloudOutline className={`h-7 w-7 ${accentClass}`} />;
   })();
 
   return (
-    <div className="relative flex min-w-0 items-center gap-1.5 border-b border-r border-slate-200 p-1 last:border-r-0 even:border-r-0 [&:nth-last-child(-n+2)]:border-b-0 dark:border-slate-700 sm:gap-2 sm:p-3">
-      <div className={`flex h-6 w-6 shrink-0 items-center justify-center rounded-full ${softBgClass} sm:h-12 sm:w-12`}>
+    <div className="relative flex min-w-0 items-center gap-3 border-b border-r border-slate-200 p-3 last:border-r-0 even:border-r-0 [&:nth-last-child(-n+2)]:border-b-0 dark:border-slate-700 sm:gap-4 sm:p-4">
+      <div className={`flex h-12 w-12 shrink-0 items-center justify-center rounded-full ${softBgClass} sm:h-14 sm:w-14`}>
         {iconNode}
       </div>
       <div className="min-w-0 flex-1">
         <div className="flex items-center gap-1">
-          <p className="truncate text-[0.64rem] font-medium text-slate-500 dark:text-slate-300 sm:text-sm">{label}</p>
+          <p className="truncate text-[0.85rem] font-semibold text-slate-500 dark:text-slate-300 sm:text-base">{label}</p>
           {tooltipText && (
             <div className="relative">
               <button
@@ -456,7 +458,7 @@ function DetailItem({
             </div>
           )}
         </div>
-        <p className="truncate text-[0.78rem] font-semibold text-slate-950 dark:text-white sm:text-xl sm:font-black">{value}</p>
+        <p className="truncate text-[1.25rem] font-black text-slate-950 dark:text-white sm:text-2xl">{value}</p>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Redesigns the AQI hero card for mobile-first readability with a larger AQI/N-D focal point, stronger status badge, and state-colored overlays aligned to AQI tokens.
- Keeps a single measurement date/time chip and removes pipeline display from the hero card.
- Enlarges environmental details grid values/icons while preserving unknown/N-D honesty.

## Files touched
- src/components/AirQualityCard.tsx

## Validation
- npm run lint
- npm run typecheck
- npm run build
- Playwright MCP mobile 390x844: mocked AQI 42 + PM2.5, verified AQI focus, AQI US, status label, PM2.5, measurement date/time, no pipeline chip, no horizontal overflow.
- Playwright MCP mobile 390x844: mocked unknown row with no AQI, pollutant, or timestamps, verified N/D, Sin lectura disponible, no PM2.5 default, no invalid date, no horizontal overflow.
- rg confirmed no AirVisual or tiempo real in src.

## Risks
- Visual density increased in the hero card; lower sections start slightly lower on mobile.
- Existing repo lint warnings remain outside this change.

## Rollback
- Revert this PR.