### PR TITLE
docs: add MtyRespira trust hardening map

### DIFF
--- a/docs/blindaje-y-cambio-de-curso.md
+++ b/docs/blindaje-y-cambio-de-curso.md
@@ -1,0 +1,175 @@
+# Mapa de blindaje y cambio de curso — MtyRespira
+
+Estado: baseline operativo recomendado
+Fecha: 2026-05-13
+
+## Propósito
+
+Este documento convierte el PreMortem de MtyRespira en un mapa accionable de blindaje. El objetivo no es ampliar superficie por impulso, sino proteger la confiabilidad del producto público antes de agregar nuevas capacidades.
+
+MtyRespira debe tratarse como un solo producto coordinado entre:
+
+- `elelier/monterrey-respira` — app pública React + TypeScript + Vite.
+- `elelier/airquality_pipeline` — pipeline Python + GitHub Actions.
+- Supabase PostgreSQL ambiental — tablas `cities`, `air_quality_readings`, `pipeline_logs` cuando aplique.
+- RPC crítica `get_latest_air_quality_per_city`.
+- Deploy público `https://mtyrespira.elelier.com`.
+
+## Cambio de curso
+
+El cambio de curso recomendado es pasar de “agregar features visibles” a “blindar confianza operativa”.
+
+Prioridad nueva:
+
+1. Confiabilidad del dato.
+2. Frescura honesta.
+3. Contrato RPC verificable.
+4. Degradación explícita.
+5. Documentación viva alineada a runtime.
+6. UX mobile solo después de no maquillar estados de datos.
+
+No se debe avanzar expansión, pronóstico, alertas personalizadas, nuevas ciudades, auth ni dashboards internos hasta cerrar los riesgos críticos de contrato y frescura.
+
+## Premisa de fracaso a evitar
+
+El peor fracaso no es que el sitio caiga. El peor fracaso es que el sitio siga en línea y muestre datos ambientales viejos, nulos o incompletos como si fueran frescos y confiables.
+
+## Invariantes no negociables
+
+- No romper `get_latest_air_quality_per_city`.
+- No romper la cadencia horaria del pipeline.
+- No romper `https://mtyrespira.elelier.com`.
+- No inventar AQI, contaminantes, clima, coordenadas ni timestamps.
+- No usar `service_role` en frontend.
+- No usar Core DB para lecturas ambientales.
+- Usar `city_id` como identidad estable; no reconciliar por nombre.
+- Tratar `reading_timestamp` como tiempo de medición.
+- Tratar `last_successful_update_at` como tiempo operativo de pipeline.
+- Fallar cerrado ante duda de contrato, frescura o integridad.
+
+## Mapa de riesgos y blindaje
+
+| Riesgo | Fracaso observable | Blindaje requerido | Área |
+| --- | --- | --- | --- |
+| Frescura sobreprometida | La UI parece actual aunque el pipeline esté atrasado | Freshness Truth UX + stale guard | app / UX |
+| RPC sin smoke test | Cambio en shape rompe o degrada silenciosamente | RPC contract smoke + fixture canónico | BD / app / pipeline |
+| Nullability no alineada | Campos nulos se muestran como cero, PM2.5 o fecha inventada | Runtime nullability hardening | app / BD |
+| Proveedor upstream falla | API expirada o limitada deja ciudades sin update | Provider continuity readiness | pipeline |
+| Docs legacy guían cambios malos | Agentes siguen Buildship/Netlify como verdad vigente | Docs drift cleanup | docs |
+| Cambios cross-repo locales | PR de un repo rompe el otro | Checklist `pipeline -> Supabase/RPC -> frontend` | QA / PM-PO |
+| Deploy no verificado | Main está bien, producción no refleja cambios | Public runtime verification gate | Cloudflare / app |
+| Histórico pesado o engañoso | Gráficas rellenan huecos o inventan series | Historical truth guard | app / BD |
+
+## Backlog recomendado
+
+### 1. RPC Contract Smoke + Runtime Nullability Verification
+
+Objetivo: crear evidencia repetible de lo que devuelve `get_latest_air_quality_per_city`.
+
+Alcance:
+
+- Validar columnas esperadas.
+- Validar nullability observada.
+- Validar timestamps UTC.
+- Validar una o más ciudades conocidas.
+- Documentar SQL/grants reales si se inspeccionan desde Supabase.
+
+No hacer:
+
+- No cambiar shape de la RPC.
+- No hacer writes live.
+- No introducir service_role fuera del pipeline.
+
+### 2. Freshness Truth UX + Stale Data Guard
+
+Objetivo: evitar que el usuario confunda refresh frontend con nueva medición.
+
+Alcance:
+
+- Mostrar diferencia entre medición y actualización de pipeline.
+- Detectar stale data.
+- Estado claro: fresco, viejo, degradado, sin lectura.
+- Evitar `tiempo real` si no corresponde a la cadencia real.
+
+### 3. Provider Continuity Readiness
+
+Objetivo: preparar fallas de WAQI/AQICN o cualquier proveedor activo sin romper la UX.
+
+Alcance:
+
+- Clasificar errores upstream.
+- Registrar última ejecución sana.
+- Mantener estado por ciudad.
+- Runbook de contingencia.
+
+### 4. Docs Drift Cleanup
+
+Objetivo: dejar clara la fuente de verdad operativa.
+
+Alcance:
+
+- Eliminar o marcar como legacy referencias a Buildship y Netlify si contradicen runtime vigente.
+- Actualizar README, roadmap y referencias.
+- Mantener `docs/shared-data-contract.md` como frontera de producto.
+
+### 5. Public Runtime Verification Gate
+
+Objetivo: después de merge, verificar que producción siga sana.
+
+Alcance:
+
+- Validar carga pública.
+- Validar selección de una ciudad conocida.
+- Validar timestamp y estado de degradación.
+- Validar que el workflow horario del pipeline esté sano.
+
+## Orden de ejecución recomendado
+
+1. Contrato y nullability.
+2. Frescura y degradación visible.
+3. Continuidad proveedor/pipeline.
+4. Limpieza documental.
+5. UX polish posterior.
+
+## Limpieza de documentación obsoleta
+
+Se consideran obsoletas como fuente de verdad vigente:
+
+- Referencias a Buildship como runtime activo del pipeline.
+- Referencias a Netlify como deploy activo si contradicen Cloudflare Pages.
+- Referencias a endpoint `GET /latest-air-quality` si se presentan como API vigente frente a la RPC Supabase.
+- Roadmaps que promueven expansión antes del blindaje de contrato/frescura.
+- Documentos bajo carpetas legacy como `docs/bye/` cuando repiten plataformas o endpoints no vigentes.
+
+Regla: si un documento legacy se conserva, debe decir explícitamente que no es fuente de verdad operativa.
+
+## Checklist para PRs futuros
+
+Antes de merge:
+
+- [ ] ¿Toca app, pipeline, BD/RPC, Cloudflare o UX?
+- [ ] ¿Afecta `reading_timestamp`, `last_successful_update_at`, cache o frescura?
+- [ ] ¿Afecta nullability o campos del contrato?
+- [ ] ¿Puede mostrar datos viejos como frescos?
+- [ ] ¿Puede inventar datos por fallback?
+- [ ] ¿Requiere validar ambos repos?
+- [ ] ¿Actualiza `docs/shared-data-contract.md` si toca contrato?
+- [ ] ¿Tiene rollback claro?
+
+Después de merge:
+
+- [ ] Validar producción en `https://mtyrespira.elelier.com`.
+- [ ] Validar workflow horario en `airquality_pipeline`.
+- [ ] Validar al menos una ciudad conocida.
+- [ ] Confirmar que no se introdujeron referencias legacy como verdad vigente.
+
+## Definición de blindaje completo
+
+MtyRespira estará blindado cuando:
+
+- La RPC crítica tenga smoke test o fixture canónico.
+- La app maneje nulls sin inventar datos.
+- La UI distinga dato fresco, viejo, degradado y faltante.
+- El pipeline tenga evidencia operativa por ciudad.
+- Los docs principales no contradigan runtime.
+- Cada PR de datos declare impacto cross-repo.

--- a/docs/bye/references.md
+++ b/docs/bye/references.md
@@ -1,140 +1,37 @@
-# Referencias de MonterreyRespira
+# Referencias legacy de MonterreyRespira
 
-Este documento recopila todas las referencias a documentación externa e interna utilizada en el proyecto MonterreyRespira.
+Estado: legacy / no fuente de verdad operativa
+Fecha: 2026-05-13
 
-## 🌐 Documentación Externa
+Este archivo conserva referencias históricas del proyecto. No debe usarse para tomar decisiones de runtime, pipeline, deploy ni contrato de datos.
 
-### Plataformas y Servicios
+La fuente de verdad vigente está en:
 
-*   **Buildship**
-    *   Orquestación y API
-    *   Workflows programados
-    *   Endpoints API
+- `docs/shared-data-contract.md`
+- `docs/architecture.md`
+- `docs/data-pipeline.md`
+- `docs/blindaje-y-cambio-de-curso.md`
+- Workflow efectivo de `elelier/airquality_pipeline`
 
-*   **Supabase**
-    *   Base de datos PostgreSQL
-    *   API REST
-    *   Row Level Security
+## Referencias históricas
 
-*   **Netlify**
-    *   Despliegue frontend
-    *   Gestión de assets
-    *   Optimización de rendimiento
+Las siguientes referencias pueden aparecer en documentos antiguos, pero no son runtime vigente salvo evidencia nueva y explícita:
 
-### APIs y Librerías
+- Buildship como orquestador activo.
+- Netlify como deploy activo.
+- Endpoint `GET /latest-air-quality` como frontera vigente de lectura.
+- API server-side propia para el frontend.
 
-*   **AirVisual (IQAir) API**
-    *   Fuente principal de datos
-    *   Límites de peticiones
-    *   Documentación de endpoints
+## Referencias vigentes de alto nivel
 
-*   **React**
-    *   Framework frontend
-    *   Documentación oficial
-    *   Ejemplos de componentes
+- App pública: `https://mtyrespira.elelier.com`
+- Frontend: `elelier/monterrey-respira`
+- Pipeline: `elelier/airquality_pipeline`
+- Frontera de datos: Supabase PostgreSQL
+- RPC crítica: `get_latest_air_quality_per_city`
 
-*   **TypeScript**
-    *   Documentación de tipos
-    *   Mejores prácticas
-    *   Configuración
+## Regla de uso
 
-## 📚 Documentación Interna
+Si este archivo contradice documentos vigentes o runtime, este archivo pierde prioridad.
 
-### Estructura del Proyecto
-
-*   **[README.md](./README.md)**
-    *   Introducción general
-    *   Características clave
-    *   Pila tecnológica
-    *   Estado del proyecto
-
-*   **[Roadmap.md](./roadmap.md)**
-    *   Plan de desarrollo
-    *   Fases de implementación
-    *   Funcionalidades futuras
-
-*   **[Changelog.md](./changelog.md)**
-    *   Historial de cambios
-    *   Versiones del proyecto
-    *   Mejoras y correcciones
-
-### Guías y Estándares
-
-*   **[Style Guide](./style-guide.md)**
-    *   Lineamientos de diseño
-    *   Componentes visuales
-    *   Sistema de temas
-    *   Paleta de colores
-
-*   **[Best Practices](./best-practices.md)**
-    *   Mejores prácticas de desarrollo
-    *   Patrones de diseño
-    *   Guías de implementación
-
-### Componentes y Arquitectura
-
-*   **[Architecture.md](./architecture.md)**
-    *   Visión general del sistema
-    *   Arquitectura frontend
-    *   Arquitectura backend
-    *   Flujo de datos
-
-*   **[Components.md](./components.md)**
-    *   Componentes reutilizables
-    *   Estructura de componentes
-    *   Propiedades y métodos
-
-### Datos y APIs
-
-*   **[Data Pipeline](./data-pipeline.md)**
-    *   Pipeline de datos
-    *   Orquestación
-    *   Base de datos
-    *   API de lectura
-
-*   **[API.md](./api.md)**
-    *   APIs externas
-    *   Implementación
-    *   Estrategias de fallback
-
-### Contribución y Desarrollo
-
-*   **[Contributing.md](./contributing.md)**
-    *   Guía de contribución
-    *   Proceso de desarrollo
-    *   Requisitos
-
-## 📝 Referencias de Código
-
-### Contextos y Estado
-
-*   **AirQualityContext**
-    *   Gestión de datos
-    *   Temas dinámicos
-    *   Estado global
-
-### Funciones y Procesos
-
-*   **Workflow Principal**
-    *   Schedule Trigger (CRON)
-    *   API Endpoint Trigger
-    *   Procesamiento de datos
-
-*   **Funciones SQL**
-    *   Consultas eficientes
-    *   Row Number
-    *   Partición de datos
-
-### Endpoints API
-
-*   **GET /latest-air-quality**
-    *   Datos procesados
-    *   Filtros
-    *   Respuestas
-
-## 📌 Notas Importantes
-
-*   Las referencias a documentación externa deben mantenerse actualizadas
-*   Las referencias internas deben seguir la estructura del proyecto
-*   Cualquier cambio en la documentación debe reflejarse en este archivo
-*   Las referencias a código deben mantenerse sincronizadas con la implementación
+No usar este archivo como base para nuevas historias de implementación.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,57 +1,129 @@
-Aquí tienes el contenido listo para reemplazar tu archivo docs/roadmap.md, reflejando fielmente el estado actual del proyecto tras 3 semanas, el avance real y los siguientes pasos recomendados. El formato es claro y profesional, siguiendo el estilo de tu documentación.
+# Roadmap — MtyRespira
 
-Roadmap de MonterreyRespira (Actualizado - Semana 3)
-Este roadmap refleja el estado actual del proyecto tras 3 semanas de desarrollo, con una separación clara entre lo ya integrado y las siguientes prioridades sugeridas.
+Estado: brownfield operativo
+Fecha: 2026-05-13
 
-1. Avance Actual (Semana 3)
-Backend & Pipeline de Datos
-[x] Configuración y despliegue de Supabase como base de datos principal (PostgreSQL).
-[x] Esquema de tablas cities y air_quality_readings creado y documentado.
-[x] Seguridad: RLS habilitado, uso de service_role para el pipeline.
-[x] Pipeline automatizado en Buildship para:
-[x] Sincronización de ciudades monitoreadas con la API de AirVisual.
-[x] Obtención y almacenamiento programado (CRON) de datos de calidad del aire cada hora.
-[x] Manejo de errores y reintentos automáticos.
-[x] Función RPC get_latest_air_quality_per_city implementada y consumida desde el frontend.
-Frontend
-[x] Estructura modular en React + TypeScript, con rutas principales y layout adaptativo.
-[x] Integración con Supabase vía API propia (no consumo directo de APIs externas en frontend).
-[x] Contexto global para calidad del aire: manejo de estado, caché local y refresco.
-[x] Componentes clave implementados:
-[x] Tarjetas y visualizaciones de calidad del aire.
-[x] Mapa interactivo y mapas de calor (heatmap).
-[x] Gráficos históricos y comparativos.
-[x] Sistema de alertas visuales.
-[x] Accesibilidad básica y soporte para temas dinámicos.
-[x] Guía de estilos y arquitectura documentadas y alineadas con el código.
-[x] Tipografía y paleta de colores arquitectónica (Montserrat, Work Sans, colores por estado AQI).
-DevOps y Calidad
-[x] Despliegue automático en Netlify.
-[x] Linting (ESLint), formateo (Prettier) y control de calidad automatizado.
-[x] Documentación técnica y de diseño actualizada.
-2. Siguientes pasos recomendados (Prioridades)
-Backend & Pipeline
-[ ] Optimizar la función RPC para mayor eficiencia si crece el volumen de datos.
-[ ] Implementar endpoint para datos históricos reales.
-[ ] Integrar nuevas fuentes de datos (ej. SIMA) cuando estén disponibles.
-[ ] Mejorar logs y telemetría del pipeline (Buildship).
-Frontend
-[ ] Implementar lazy loading para componentes pesados (mapas, gráficos).
-[ ] Mejorar la experiencia móvil (optimización de UI/UX en dispositivos pequeños).
-[ ] Añadir modo para personas daltónicas y accesibilidad avanzada (WCAG 2.1 AA).
-[ ] Permitir preferencias de usuario persistentes (requiere Supabase Auth).
-[ ] Mejorar sistema de alertas (push/email) y configuración de umbrales personalizados.
-[ ] Añadir sección de participación ciudadana (reportes, galería, compartir en redes).
-[ ] Desarrollar vista de pronóstico de calidad del aire (integrar modelos o APIs de forecast).
-Visualización y Analítica
-[ ] Implementar comparativas entre ciudades.
-[ ] Añadir vistas de tendencias y patrones a largo plazo.
-[ ] Preparar la base para análisis predictivo y visualización avanzada.
-Escalabilidad y Expansión
-[ ] Planificar la expansión a otras ciudades de México.
-[ ] Preparar la infraestructura para soportar mayor volumen y diversidad de datos.
-3. Visión a mediano y largo plazo
-Plataforma educativa ambiental y gamificación.
-Calculadora de huella de carbono personal.
-Modelos de predicción y alertas preventivas.
-Expansión nacional y comparativas regionales.
+## Cambio de curso
+
+La prioridad actual de MtyRespira no es expandir superficie visible. La prioridad es blindar confianza operativa antes de agregar features nuevas.
+
+El roadmap vigente se ordena alrededor de cuatro principios:
+
+1. Contrato de datos verificable.
+2. Frescura honesta.
+3. Degradación explícita.
+4. Continuidad de pipeline y proveedor.
+
+## Fase 1 — Blindaje crítico
+
+### Story 1.1 — RPC Contract Smoke + Runtime Nullability Verification
+
+Objetivo: crear evidencia repetible de lo que devuelve `get_latest_air_quality_per_city`.
+
+Alcance:
+
+- Validar columnas esperadas.
+- Validar nullability observada.
+- Validar timestamps UTC.
+- Validar una o más ciudades conocidas.
+- Dejar fixture o smoke test canónico.
+
+Criterio de salida:
+
+- Existe evidencia verificable del payload real.
+- `docs/shared-data-contract.md` queda actualizado si se detecta drift.
+
+### Story 1.2 — Freshness Truth UX + Stale Data Guard
+
+Objetivo: evitar que la app comunique datos viejos como si fueran frescos.
+
+Alcance:
+
+- Distinguir medición, actualización de pipeline y refresh de frontend.
+- Mostrar estado fresco, viejo, degradado o faltante.
+- Evitar lenguaje de “tiempo real” cuando exceda la cadencia real del productor.
+
+Criterio de salida:
+
+- La UI no sobrepromete frescura.
+- Un dato viejo o dudoso entra en estado explícito, no normal.
+
+### Story 1.3 — Provider Continuity Readiness
+
+Objetivo: preparar fallas del proveedor activo sin romper la experiencia pública.
+
+Alcance:
+
+- Clasificar errores upstream.
+- Registrar estado por ciudad.
+- Documentar runbook de contingencia.
+- Evitar fallback productivo no verificado.
+
+Criterio de salida:
+
+- El equipo puede distinguir error upstream, dato viejo, ciudad sin update y estado sano.
+
+### Story 1.4 — Public Runtime Verification Gate
+
+Objetivo: verificar producción después de cambios relevantes.
+
+Alcance:
+
+- Validar `https://mtyrespira.elelier.com`.
+- Validar workflow horario del pipeline.
+- Validar una ciudad conocida contra el contrato.
+- Registrar evidencia básica posterior a release.
+
+Criterio de salida:
+
+- Cada release relevante tiene evidencia mínima de app, pipeline y contrato.
+
+## Fase 2 — Limpieza y gobernanza
+
+### Story 2.1 — Docs Drift Cleanup
+
+Objetivo: eliminar referencias o afirmaciones obsoletas que contradigan runtime vigente.
+
+Alcance:
+
+- Marcar Buildship como legacy si aparece como runtime activo.
+- Marcar Netlify como legacy si aparece como deploy activo.
+- Remover endpoints legacy presentados como API vigente.
+- Alinear README, arquitectura, pipeline, roadmap y referencias.
+
+### Story 2.2 — Cross-Repo Change Checklist
+
+Objetivo: evitar cambios locales que rompan el producto coordinado.
+
+Todo PR que toque datos debe declarar impacto sobre:
+
+```text
+pipeline -> Supabase/RPC -> frontend -> UX
+```
+
+## Fase 3 — UX y visualización posterior
+
+Solo después de cerrar Fase 1:
+
+- Mejoras mobile-first.
+- Pulido de tarjetas AQI.
+- Visualizaciones históricas más claras.
+- Mejoras de accesibilidad.
+- Comparativas entre ciudades.
+
+## Fuera de alcance hasta nuevo aviso
+
+- Auth de usuarios.
+- Alertas personalizadas.
+- Nuevas fuentes productivas sin contrato verificado.
+- Pronóstico ambiental.
+- Expansión nacional.
+- Gamificación.
+- Nuevas lecturas ambientales fuera del contrato actual.
+
+## Documentos relacionados
+
+- `docs/shared-data-contract.md`
+- `docs/data-pipeline.md`
+- `docs/architecture.md`
+- `docs/blindaje-y-cambio-de-curso.md`


### PR DESCRIPTION
## Resumen

Documenta el mapa de blindaje y cambio de curso para MtyRespira, con foco en confianza operativa antes de nuevas features.

## Cambios

- Agrega `docs/blindaje-y-cambio-de-curso.md` con el PreMortem convertido en mapa accionable.
- Reemplaza `docs/roadmap.md` legacy por roadmap de blindaje:
  - RPC Contract Smoke + Runtime Nullability Verification
  - Freshness Truth UX + Stale Data Guard
  - Provider Continuity Readiness
  - Public Runtime Verification Gate
  - Docs Drift Cleanup
- Marca `docs/bye/references.md` como legacy/no fuente de verdad operativa.

## Fuera de alcance

- No runtime changes.
- No frontend code.
- No pipeline code.
- No Supabase writes.
- No secrets.
- No cambios a AQI, históricos, geolocalización ni contrato de datos.

## Pendiente explícito

- Intenté actualizar `docs/README.md` para retirar referencias legacy, pero el conector bloqueó esa llamada. Queda recomendado como ajuste posterior/manual.

## Validación

Documentación solamente. No requiere build/runtime.
