### PR TITLE
feat: add freshness truth UX guard

### DIFF
--- a/docs/freshness-truth-ux.md
+++ b/docs/freshness-truth-ux.md
@@ -1,0 +1,37 @@
+# Freshness Truth UX
+
+Status: Story 1.2 frontend note
+
+Scope: `monterrey-respira` frontend only. No Supabase schema changes, no RPC changes, no pipeline runtime changes, no provider changes, and no service role in the app.
+
+## Timestamp roles
+
+- `reading_timestamp` is the environmental measurement time. It drives the dashboard freshness status.
+- `last_successful_update_at` is pipeline success traceability. It may be shown as `Pipeline ...`, but it is not measurement freshness.
+- Frontend cache or refresh time only means the app fetched or read data. It must not be described as a new measurement.
+
+## Latest-reading thresholds
+
+| Status | Age by `reading_timestamp` | UI copy |
+| --- | --- | --- |
+| `fresh` | `<= 2h` | `Medicion reciente` |
+| `stale` | `> 2h` and `<= 6h` | `Medicion con retraso` |
+| `old` | `> 6h` | `Dato viejo` |
+| `unknown` | missing, invalid, future timestamp outside tolerance, or no reliable AQI | `Sin lectura disponible` |
+
+## Fail-closed rules
+
+- Missing latest RPC row degrades to `unknown`.
+- `aqi_us: null` degrades to `unknown`; it must never become healthy AQI `0`.
+- Missing or invalid `reading_timestamp` degrades freshness to `unknown`.
+- Stale or old readings may keep the AQI value visible, but the UI must mark the reading as degraded and show caution copy.
+- Missing secondary weather fields render as `N/D`; they are not invented.
+
+## UI presentation rule
+
+The AQI card should distinguish:
+
+- `Medicion ...` from `reading_timestamp`.
+- `Pipeline ...` from `last_successful_update_at`.
+
+Do not use stronger freshness language than the hourly producer cadence can support.

--- a/src/components/AirQualityCard.tsx
+++ b/src/components/AirQualityCard.tsx
@@ -33,6 +33,7 @@ import {
   hasReliableAqi,
 } from '../utils/airQualityDisplay';
 import { useAirQuality } from '../context/AirQualityContext';
+import { getFreshnessDisplayCopy } from '../utils/freshness';
 
 interface AirQualityCardProps {
   data: AirQualityData;
@@ -143,19 +144,6 @@ function getStatusIcon(status: AirQualityStatus, className: string) {
   }
 }
 
-function getFreshnessLabel(data: AirQualityData) {
-  switch (data.measurementFreshness) {
-    case 'stale':
-      return 'Ultima medicion';
-    case 'degraded':
-      return 'Ultima medicion';
-    case 'unknown':
-      return 'Ultima medicion';
-    default:
-      return 'Ultima medicion';
-  }
-}
-
 export default function AirQualityCard({ data, className = '' }: AirQualityCardProps) {
   const [showDetails, setShowDetails] = useState<boolean>(true);
   const [hasMounted, setHasMounted] = useState(false);
@@ -175,7 +163,9 @@ export default function AirQualityCard({ data, className = '' }: AirQualityCardP
   const mainPollutantLabel = data.main_pollutant_us
     ? getPollutantInfo(data.main_pollutant_us).name
     : 'N/D';
+  const freshnessCopy = getFreshnessDisplayCopy(data.measurementFreshness);
   const measurementTime = reliableAqi ? formatNullableTimestamp(data.timestamp) : 'N/D';
+  const pipelineTime = formatNullableTimestamp(data.last_successful_update_at ?? null);
 
   return (
     <motion.section
@@ -247,11 +237,22 @@ export default function AirQualityCard({ data, className = '' }: AirQualityCardP
             {copy.description}
           </p>
 
-          <div className="mt-4 max-w-[16.5rem]">
+          {data.degradationReason && (
+            <p className="mt-3 rounded-2xl bg-white/18 px-3 py-2 text-[0.86rem] font-semibold leading-snug text-white shadow-sm backdrop-blur-md sm:text-base">
+              {data.degradationReason}
+            </p>
+          )}
+
+          <div className="mt-4 grid max-w-[34rem] grid-cols-1 gap-2 sm:grid-cols-2">
             <InfoPill
               icon={<IoTimeOutline className="h-6 w-6" />}
-              label={getFreshnessLabel(data)}
-              value={measurementTime}
+              label={freshnessCopy.label}
+              value={`Medicion ${measurementTime}`}
+            />
+            <InfoPill
+              icon={<IoCloudOutline className="h-6 w-6" />}
+              label="Trazabilidad"
+              value={`Pipeline ${pipelineTime}`}
             />
           </div>
         </div>
@@ -463,4 +464,3 @@ function DetailItem({
     </div>
   );
 }
-

--- a/src/context/AirQualityContext.tsx
+++ b/src/context/AirQualityContext.tsx
@@ -20,6 +20,10 @@ import {
   findCityById,
 } from '../utils/cityRoutingUtils';
 import { hasReliableAqi } from '../utils/airQualityDisplay';
+import {
+  getMeasurementFreshness,
+  getMeasurementFreshnessReason,
+} from '../utils/freshness';
 
 type CityOption = (typeof MONTERREY_LOCATIONS_WITH_COORDS)[number];
 
@@ -53,23 +57,21 @@ interface AirQualityProviderProps {
 
 const CACHE_KEY = 'airQualityDataCache';
 const CACHE_EXPIRATION_TIME = 60 * 60 * 1000;
-const MEASUREMENT_DEGRADED_HOURS = 2;
-const MEASUREMENT_STALE_HOURS = 6;
 
 function getRpcFailureReason(error: unknown): string {
   if (!isAirQualityServiceError(error)) {
-    return 'No se pudo consultar la fuente pública de calidad del aire.';
+    return 'No se pudo consultar la fuente publica de calidad del aire.';
   }
 
   switch (error.code) {
     case 'supabase_config_missing':
-      return 'El deployment público no tiene configurada la conexión de Supabase.';
+      return 'El deployment publico no tiene configurada la conexion de Supabase.';
     case 'supabase_rpc_error':
-      return 'Supabase rechazó o no pudo ejecutar la RPC pública de calidad del aire.';
+      return 'Supabase rechazo o no pudo ejecutar la RPC publica de calidad del aire.';
     case 'supabase_unexpected_response':
-      return 'La RPC de calidad del aire respondió con un formato inesperado.';
+      return 'La RPC de calidad del aire respondio con un formato inesperado.';
     default:
-      return 'No se pudo consultar la fuente pública de calidad del aire.';
+      return 'No se pudo consultar la fuente publica de calidad del aire.';
   }
 }
 
@@ -104,50 +106,6 @@ function buildDegradedAirQualityData(city: CityOption, reason: string): AirQuali
   };
 }
 
-function getMeasurementAgeHours(readingTimestamp: string): number | null {
-  const readingTime = new Date(readingTimestamp).getTime();
-
-  if (Number.isNaN(readingTime)) {
-    return null;
-  }
-
-  return (Date.now() - readingTime) / (60 * 60 * 1000);
-}
-
-function getMeasurementFreshness(readingTimestamp: string): AirQualityData['measurementFreshness'] {
-  const ageHours = getMeasurementAgeHours(readingTimestamp);
-
-  if (ageHours === null) {
-    return 'unknown';
-  }
-
-  if (ageHours > MEASUREMENT_STALE_HOURS) {
-    return 'stale';
-  }
-
-  if (ageHours > MEASUREMENT_DEGRADED_HOURS) {
-    return 'degraded';
-  }
-
-  return 'fresh';
-}
-
-function getMeasurementFreshnessReason(
-  freshness: AirQualityData['measurementFreshness'],
-  cityName: string,
-): string | undefined {
-  switch (freshness) {
-    case 'stale':
-      return `Ultima medicion disponible para ${cityName}.`;
-    case 'degraded':
-      return `La medicion ambiental de ${cityName} tiene retraso frente a la cadencia esperada.`;
-    case 'unknown':
-      return `No se pudo validar la hora de medicion ambiental para ${cityName}.`;
-    default:
-      return undefined;
-  }
-}
-
 function getCityAvailability(row: CityAirQualityData | undefined): CityDataAvailability {
   if (!row) {
     return 'missing';
@@ -161,7 +119,7 @@ function getCityDisabledReason(availability: CityDataAvailability): string | und
     case 'missing':
       return 'Sin datos recientes';
     case 'invalid-aqi':
-      return 'Última lectura no disponible';
+      return 'Ultima lectura no disponible';
     default:
       return undefined;
   }
@@ -203,7 +161,7 @@ function transformApiResponse(
   if (!hasReliableAqi(cityData.aqi_us)) {
     return buildDegradedAirQualityData(
       city,
-      `Última lectura no disponible para ${city.name}.`,
+      `Ultima lectura no disponible para ${city.name}.`,
     );
   }
 
@@ -350,14 +308,14 @@ export function AirQualityProvider({ children }: AirQualityProviderProps) {
         setCityDataArray([]);
         setAirQualityData(degradedData);
         setTheme(getAirQualityTheme('unknown'));
-        setError('No se pudieron cargar datos frescos de calidad del aire.');
+        setError('No se pudieron cargar datos de calidad del aire.');
       }
     } catch (err) {
       console.error('Error fetching air quality data:', err);
       const degradedData = buildDegradedAirQualityData(selectedCity, getRpcFailureReason(err));
       setAirQualityData(degradedData);
       setTheme(getAirQualityTheme('unknown'));
-      setError('No se pudieron cargar datos frescos de calidad del aire.');
+      setError('No se pudieron cargar datos de calidad del aire.');
     } finally {
       setLoading(false);
     }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -43,7 +43,7 @@ export type AirQualityHistoryMetric = 'aqi_us' | 'temperature_c' | 'humidity_per
 
 export type AirQualityDataQuality = 'fresh' | 'degraded';
 
-export type MeasurementFreshness = 'fresh' | 'degraded' | 'stale' | 'unknown';
+export type MeasurementFreshness = 'fresh' | 'stale' | 'old' | 'unknown';
 
 export type CityDataAvailability = 'available' | 'missing' | 'invalid-aqi';
 

--- a/src/utils/freshness.ts
+++ b/src/utils/freshness.ts
@@ -1,0 +1,95 @@
+import { MeasurementFreshness } from '../types';
+
+export const FRESHNESS_STALE_THRESHOLD_HOURS = 2;
+export const FRESHNESS_OLD_THRESHOLD_HOURS = 6;
+const FUTURE_CLOCK_SKEW_TOLERANCE_HOURS = 5 / 60;
+
+export interface FreshnessDisplayCopy {
+  label: string;
+  shortLabel: string;
+}
+
+export function getMeasurementAgeHours(
+  readingTimestamp: string | null | undefined,
+  now = Date.now(),
+): number | null {
+  if (!readingTimestamp) {
+    return null;
+  }
+
+  const readingTime = new Date(readingTimestamp).getTime();
+
+  if (Number.isNaN(readingTime)) {
+    return null;
+  }
+
+  const ageHours = (now - readingTime) / (60 * 60 * 1000);
+
+  if (ageHours < -FUTURE_CLOCK_SKEW_TOLERANCE_HOURS) {
+    return null;
+  }
+
+  return Math.max(ageHours, 0);
+}
+
+export function getMeasurementFreshness(
+  readingTimestamp: string | null | undefined,
+  now = Date.now(),
+): MeasurementFreshness {
+  const ageHours = getMeasurementAgeHours(readingTimestamp, now);
+
+  if (ageHours === null) {
+    return 'unknown';
+  }
+
+  if (ageHours > FRESHNESS_OLD_THRESHOLD_HOURS) {
+    return 'old';
+  }
+
+  if (ageHours > FRESHNESS_STALE_THRESHOLD_HOURS) {
+    return 'stale';
+  }
+
+  return 'fresh';
+}
+
+export function getMeasurementFreshnessReason(
+  freshness: MeasurementFreshness,
+  cityName: string,
+): string | undefined {
+  switch (freshness) {
+    case 'old':
+      return `Dato viejo para ${cityName}; revisar con cautela.`;
+    case 'stale':
+      return `La medición ambiental de ${cityName} tiene retraso frente a la cadencia esperada.`;
+    case 'unknown':
+      return `No se pudo validar la hora de medición ambiental para ${cityName}.`;
+    default:
+      return undefined;
+  }
+}
+
+export function getFreshnessDisplayCopy(freshness: MeasurementFreshness): FreshnessDisplayCopy {
+  switch (freshness) {
+    case 'fresh':
+      return {
+        label: 'Medición reciente',
+        shortLabel: 'Reciente',
+      };
+    case 'stale':
+      return {
+        label: 'Medición con retraso',
+        shortLabel: 'Con retraso',
+      };
+    case 'old':
+      return {
+        label: 'Dato viejo',
+        shortLabel: 'Viejo',
+      };
+    default:
+      return {
+        label: 'Sin lectura disponible',
+        shortLabel: 'Sin lectura',
+      };
+  }
+}


### PR DESCRIPTION
## Summary
- Centralizes latest-reading freshness logic in `src/utils/freshness.ts` using `reading_timestamp` as the only measurement freshness source.
- Aligns frontend freshness vocabulary to `fresh | stale | old | unknown`.
- Updates `AirQualityContext` to fail closed through the shared helper and keep degraded/unknown states explicit.
- Updates `AirQualityCard` to distinguish `Medicion ...` from `Pipeline ...` and surface caution copy for stale/old/unknown readings.
- Adds `docs/freshness-truth-ux.md` with Story 1.2 thresholds and fail-closed rules.

## Impact
- Pipeline -> unchanged.
- Supabase/RPC -> unchanged.
- Frontend -> freshness status is now centralized and consumed by context/card.
- UX -> users can distinguish measurement freshness from pipeline traceability.

## Files touched
- `src/utils/freshness.ts`
- `src/types/index.ts`
- `src/context/AirQualityContext.tsx`
- `src/components/AirQualityCard.tsx`
- `docs/freshness-truth-ux.md`

## Validation
- To verify: `npm run lint`
- To verify: `npm run typecheck` if available
- To verify: `npm run build`

## Risks
- Copy now shows a second traceability pill in the AQI card; mobile spacing should be checked at common viewports.
- Validation was not executed from this connector session.

## Rollback
- Revert this PR. No schema, RPC, pipeline, provider, secret, service role, or Supabase live changes were made.