### PR TITLE
docs: add canonical MtyRespira project docs baseline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,158 @@
+# AGENTS.md — MtyRespira
+
+Status: canonical agent baseline  
+Scope: `elelier/monterrey-respira` with `elelier/airquality_pipeline` as the read-only reference repo when a change touches environmental data flow.
+
+## Product boundary
+
+MtyRespira is the public air-quality product for Monterrey and its metropolitan area.
+
+Canonical public app:
+
+- `https://mtyrespira.elelier.com/`
+
+Repos:
+
+- App/public UX: `elelier/monterrey-respira`
+- Environmental data pipeline: `elelier/airquality_pipeline`
+
+Shared environmental data boundary:
+
+```text
+provider -> airquality_pipeline -> Supabase tables -> get_latest_air_quality_per_city -> frontend
+```
+
+Current environmental database concepts:
+
+- Supabase PostgreSQL environmental project
+- Tables: `cities`, `air_quality_readings`, `pipeline_logs` when applicable
+- Critical RPC: `get_latest_air_quality_per_city`
+
+Provider state:
+
+- Active provider: WAQI/AQICN when confirmed by current pipeline/runtime evidence
+- Legacy/fallback provider: IQAir/AirVisual when confirmed by current pipeline/runtime evidence
+
+If provider docs and runtime disagree, verify `airquality_pipeline` before changing product claims.
+
+## Operating rules for agents
+
+- Work only on MtyRespira in this repo context.
+- Do not mix this project with Oficina Digital, Core DB CRM, MiRancho, ConectaTech, Polymarket, QR Scan Tracker, or any other product.
+- Do not push directly to `main`.
+- Every change must go through a branch and pull request.
+- Do not commit secrets.
+- Do not expose service-role credentials in the frontend/app.
+- `service_role` belongs only to the pipeline if it is already configured as a protected secret.
+- Do not invent environmental data: AQI, pollutant, weather, coordinates, timestamps, cities, provider status, or freshness.
+- Do not break AQI rendering, historical views, geolocation, or the shared data contract.
+- Do not rename, remove, or silently change the RPC `get_latest_air_quality_per_city`.
+- Do not change Supabase schema, RPC behavior, pipeline runtime, provider behavior, or writes live unless the story explicitly authorizes it.
+- Do not promise "tiempo real" as a product claim. Use honest language such as "lecturas disponibles", "medición reportada", or "actualización por pipeline horario".
+
+## When to inspect each repo
+
+Use `monterrey-respira` when the change touches:
+
+- public UI/UX
+- AQI card or AQI visual state
+- city selector/search/geolocation
+- frontend cache or refresh behavior
+- copy, SEO, README, public docs, or routing
+- Supabase anon client consumption
+
+Use `airquality_pipeline` as reference when the change touches or claims anything about:
+
+- provider behavior
+- hourly workflow
+- ingestion cadence
+- payload validation
+- city synchronization
+- `cities` or `air_quality_readings` writes
+- pipeline logs/statuses
+- `last_successful_update_at`
+
+Do not edit `airquality_pipeline` from this repo unless the story explicitly says to open a separate pipeline PR.
+
+## Core DB rule
+
+Core DB may be referenced only for product signals or product feedback signals. It is not the source of environmental readings and must not be used for AQI, weather, historical air-quality readings, or provider pipeline state.
+
+## Canonical documentation
+
+Use this hierarchy when docs, runtime, and memory disagree:
+
+1. Runtime and workflow evidence from `airquality_pipeline` for data production.
+2. `docs/shared-data-contract.md` for the shared data boundary.
+3. `docs/PRD.md` for product scope and requirements.
+4. `docs/architecture.md` for architecture of record.
+5. `docs/roadmap.md` for story order and gates.
+6. `docs/freshness-truth-ux.md` for freshness UX semantics.
+7. `docs/blindaje-y-cambio-de-curso.md` for risk posture and change-of-course rationale.
+8. README for public contributor orientation only.
+
+If there is conflict, do not guess. Mark the drift and update documentation in the same PR when in scope.
+
+## Required PR notes
+
+Every PR must explain impact on:
+
+```text
+app / pipeline / Supabase RPC / BD MtyRespira / UX / Cloudflare
+```
+
+For data-affecting PRs, also include:
+
+```text
+pipeline -> Supabase/RPC -> frontend -> UX
+```
+
+Required PR sections:
+
+- Summary
+- Area touched
+- Contract impact
+- Validation
+- Risks / pending items
+- Rollback
+
+## Validation expectations
+
+Documentation-only changes:
+
+- Review relative links.
+- Run or document equivalent grep/ripgrep for obsolete claims when possible.
+
+Frontend changes:
+
+```bash
+npm run lint
+npm run build
+```
+
+If available:
+
+```bash
+npm run typecheck
+```
+
+Pipeline changes:
+
+```bash
+pytest
+```
+
+Contract changes:
+
+- Validate shape and semantics of `get_latest_air_quality_per_city`.
+- Update `docs/shared-data-contract.md` in the same PR or a clearly coordinated rollout.
+- Document rollback.
+
+## Prohibited shortcuts
+
+- No silent fallback that makes old, missing, null, or unreliable data look fresh.
+- No AQI `0` as a healthy substitute for missing AQI.
+- No hidden provider changes.
+- No new environmental source without contract and rollout plan.
+- No runtime server dependency for the public frontend unless architecture is explicitly revised.
+- No claims based only on stale README or old docs.

--- a/README.md
+++ b/README.md
@@ -2,16 +2,18 @@
 
 ![MonterreyRespira Logo](public/mty.png)
 
-MonterreyRespira es una aplicación web que proporciona información en tiempo real sobre la calidad del aire en Monterrey y su área metropolitana. Diseñada para ayudar a los ciudadanos a comprender y monitorear la calidad del aire que respiran diariamente.
+MonterreyRespira es una aplicación web pública que presenta lecturas disponibles de calidad del aire para Monterrey y su área metropolitana.
+
+El producto ayuda a las personas a consultar AQI, contaminante principal cuando está disponible, contexto ambiental y la frescura de la medición reportada. No promete monitoreo en tiempo real: la app distingue entre hora de medición, actualización del pipeline y estados degradados o sin lectura.
 
 ## ✨ Características
 
-- 📊 Visualización de datos de calidad del aire en tiempo real
-- 🗺️ Mapas interactivos con estaciones de monitoreo
-- 📈 Gráficos históricos de contaminantes
-- 🔍 Información detallada sobre contaminantes y sus efectos en la salud
+- 📊 Visualización de lecturas disponibles de calidad del aire
+- 🗺️ Mapa interactivo y selección de ciudad
+- 📈 Gráficos históricos de contaminantes cuando hay datos disponibles
+- 🔍 Información sobre contaminantes y efectos en la salud
 - 📱 Diseño responsive optimizado para dispositivos móviles
-- 🌡️ Sistema de alertas basado en la calidad del aire actual
+- 🕒 Freshness Truth UX: medición reciente, con retraso, vieja o sin lectura disponible
 
 ## 🛠️ Tecnologías
 
@@ -20,20 +22,37 @@ MonterreyRespira es una aplicación web que proporciona información en tiempo r
 - **Visualización:** Chart.js, Leaflet
 - **Animaciones:** Framer Motion
 - **Iconos:** React Icons
-- **APIs:** IQAir, OpenAQ, SIMA (en desarrollo)
+- **Datos:** Supabase RPC `get_latest_air_quality_per_city`
+- **Pipeline ambiental:** repositorio `elelier/airquality_pipeline`
+- **Hosting app:** Cloudflare Pages
+
+## 🧭 Arquitectura resumida
+
+```text
+provider -> airquality_pipeline -> Supabase tables -> get_latest_air_quality_per_city -> frontend
+```
+
+Conceptos críticos:
+
+- `reading_timestamp` = tiempo de medición ambiental.
+- `last_successful_update_at` = trazabilidad de éxito del pipeline.
+- `get_latest_air_quality_per_city` = RPC crítica consumida por el frontend.
+- `cities` y `air_quality_readings` = tablas ambientales principales.
+
+Core DB no se usa para lecturas ambientales.
 
 ## 🚀 Comenzando
 
 ### Prerequisitos
 
 - Node.js 18.x o superior
-- Bun (recomendado) o npm
+- Bun recomendado o npm
 
 ### Instalación
 
 1. Clona el repositorio:
    ```bash
-   git clone https://github.com/tuusuario/monterrey-respira.git
+   git clone https://github.com/elelier/monterrey-respira.git
    cd monterrey-respira
    ```
 
@@ -47,31 +66,37 @@ MonterreyRespira es una aplicación web que proporciona información en tiempo r
    bun dev
    ```
 
-4. Abre [http://localhost:5173](http://localhost:5173) en tu navegador
+4. Abre [http://localhost:5173](http://localhost:5173) en tu navegador.
 
-## 📚 Documentación
+## 📚 Documentación canónica
 
-La documentación completa del proyecto se encuentra en la carpeta [docs](./docs):
+La documentación principal vive en la carpeta [docs](./docs):
 
-- [Guía de Estilo](./docs/style-guide.md)
+- [Reglas para agentes](./AGENTS.md)
+- [Índice documental](./docs/DOCUMENTATION_INDEX.md)
+- [PRD](./docs/PRD.md)
 - [Arquitectura](./docs/architecture.md)
-- [API](./docs/api.md)
 - [Roadmap](./docs/roadmap.md)
+- [Contrato compartido de datos](./docs/shared-data-contract.md)
+- [Freshness Truth UX](./docs/freshness-truth-ux.md)
+- [Mapa de blindaje y cambio de curso](./docs/blindaje-y-cambio-de-curso.md)
+- [Guía de Estilo](./docs/style-guide.md)
+- [API](./docs/api.md)
 - [Contribución](./docs/contributing.md)
 
 ## 🤝 Contribuir
 
-Las contribuciones son bienvenidas. Por favor, lee la [guía de contribución](./docs/contributing.md) para más detalles.
+Las contribuciones son bienvenidas dentro del alcance de MtyRespira. Antes de abrir cambios, lee [AGENTS.md](./AGENTS.md) y la [guía de contribución](./docs/contributing.md).
 
 ## 📝 Licencia
 
-Este proyecto está licenciado bajo la Licencia MIT - ver el archivo [LICENSE](LICENSE) para más detalles.
+Este proyecto está licenciado bajo la Licencia MIT. Consulta el archivo [LICENSE](LICENSE) para más detalles.
 
 ## 📧 Contacto
 
-Para preguntas o sugerencias, por favor abre un issue en este repositorio.
+Para preguntas o sugerencias, abre un issue en este repositorio.
 
 ## 🙏 Agradecimientos
 
-- A todas las organizaciones que proporcionan datos abiertos sobre calidad del aire
-- A la comunidad de desarrolladores de Monterrey
+- A las organizaciones y comunidades que publican información ambiental.
+- A la comunidad de desarrolladores de Monterrey.

--- a/docs/DOCUMENTATION_INDEX.md
+++ b/docs/DOCUMENTATION_INDEX.md
@@ -1,0 +1,71 @@
+# Documentation Index — MtyRespira
+
+Status: canonical documentation map  
+Date: 2026-05-21
+
+## Purpose
+
+This index explains which documents govern MtyRespira and how agents should resolve drift.
+
+MtyRespira must remain scoped to the public air-quality product for Monterrey. Do not mix this documentation with Oficina Digital, Core DB CRM, MiRancho, ConectaTech, QR Scan Tracker, Polymarket, or any other project.
+
+## Canonical docs
+
+| Document | Role | Notes |
+| --- | --- | --- |
+| `AGENTS.md` | Agent execution rules | Start here before any agent-driven change. |
+| `docs/PRD.md` | Product requirements baseline | Defines product scope, users, requirements, out-of-scope items, and current gate. |
+| `docs/architecture.md` | Architecture of record | Canonical architecture file. Keep lowercase path to avoid duplicate drift. |
+| `docs/roadmap.md` | Roadmap of record | Canonical story order and stop/gates. Keep lowercase path to avoid duplicate drift. |
+| `docs/shared-data-contract.md` | Shared data contract | Canonical boundary for `pipeline -> Supabase/RPC -> frontend`. |
+| `docs/freshness-truth-ux.md` | Freshness UX semantics | Canonical copy/threshold rules for measurement freshness. |
+| `docs/blindaje-y-cambio-de-curso.md` | Risk posture | Premortem-derived guardrails and change-of-course map. |
+| `README.md` | Public contributor orientation | Must stay honest, but is not the deepest source of truth. |
+
+## Explicit canonical path decisions
+
+- Architecture stays at `docs/architecture.md`.
+- Roadmap stays at `docs/roadmap.md`.
+- PRD lives at `docs/PRD.md`.
+- Agent rules live at root `AGENTS.md`.
+
+Do not create duplicate uppercase/lowercase variants unless a future migration deliberately redirects old paths.
+
+## Source-of-truth hierarchy
+
+When files disagree:
+
+1. Current runtime/workflow evidence.
+2. `docs/shared-data-contract.md`.
+3. `docs/PRD.md`.
+4. `docs/architecture.md`.
+5. `docs/roadmap.md`.
+6. `docs/freshness-truth-ux.md`.
+7. `docs/blindaje-y-cambio-de-curso.md`.
+8. `README.md`.
+
+## Drift cleanup rules
+
+Any mention of these terms must be reviewed before merge:
+
+```bash
+rg "tiempo real|AirVisual|Buildship|Netlify|service_role|Core DB" README.md docs AGENTS.md
+```
+
+Allowed appearances:
+
+- Legacy context clearly marked as legacy.
+- Prohibitions or security rules.
+- Provider state that is explicitly tied to current runtime evidence.
+- Core DB clarification that it is not used for environmental readings.
+
+Disallowed appearances:
+
+- `tiempo real` as a product promise.
+- Buildship/Netlify as active runtime if current evidence says otherwise.
+- `service_role` in frontend guidance.
+- Core DB as storage for environmental readings.
+
+## Current gate
+
+Story 1.3 — Provider Continuity Readiness remains blocked until Story 1.2.1 — Canonical Project Docs Stop is merged.

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -1,0 +1,214 @@
+# PRD — MtyRespira
+
+Status: canonical brownfield baseline  
+Date: 2026-05-21  
+Owner: EL
+
+## 1. Product summary
+
+MtyRespira is a public web app that helps people in Monterrey and its metropolitan area understand available air-quality readings by city.
+
+The product is brownfield and already operates publicly at:
+
+- `https://mtyrespira.elelier.com/`
+
+The current product value is not a promise of real-time monitoring. The value is an honest, readable presentation of reported environmental measurements, their AQI context, and their freshness state.
+
+## 2. Current system baseline
+
+MtyRespira operates as one coordinated product across:
+
+- `elelier/monterrey-respira`: public React + TypeScript + Vite frontend.
+- `elelier/airquality_pipeline`: Python + GitHub Actions environmental data pipeline.
+- Supabase PostgreSQL environmental database.
+
+Current shared data concepts:
+
+- Tables: `cities`, `air_quality_readings`, `pipeline_logs` when applicable.
+- Critical RPC: `get_latest_air_quality_per_city`.
+- Public app hosting target: Cloudflare Pages.
+- Current public app URL: `https://mtyrespira.elelier.com/`.
+
+Canonical data flow:
+
+```text
+provider -> airquality_pipeline -> Supabase tables -> get_latest_air_quality_per_city -> frontend -> public UX
+```
+
+## 3. Objective for this brownfield phase
+
+Stabilize trust before expanding features.
+
+The product must evolve without breaking:
+
+- AQI interpretation.
+- Historical readings.
+- Geolocation behavior.
+- The shared data contract.
+- The public app.
+- The hourly producer assumptions.
+- The distinction between measurement time and pipeline update time.
+
+## 4. Users
+
+Primary users:
+
+- People in Monterrey and nearby municipalities checking available local air-quality readings.
+- People deciding whether to take basic precautions based on AQI and pollutant context.
+
+Maintainer/operator users:
+
+- Product and engineering maintainers validating public UX.
+- Operators reviewing pipeline/provider continuity.
+- Agents working on small, safe PRs under product guardrails.
+
+## 5. Success criteria
+
+User success:
+
+- A user can select a supported city and understand the AQI state, main pollutant if available, and measurement freshness.
+- A user can distinguish a recent reading from a delayed, old, degraded, or unavailable reading.
+- The UI does not represent missing or unreliable data as healthy/fresh.
+
+Operational success:
+
+- The project has canonical docs for PRD, architecture, roadmap, and agent rules.
+- Future stories follow the documented roadmap instead of being invented from memory.
+- Provider continuity work does not begin until this baseline is merged.
+- Runtime claims in README and docs do not contradict Freshness Truth UX.
+
+Technical success:
+
+- `get_latest_air_quality_per_city` remains the critical read boundary.
+- `reading_timestamp` remains the measurement-time source for freshness.
+- `last_successful_update_at` remains pipeline traceability, not measurement freshness.
+- No frontend code uses service-role credentials.
+- Environmental readings remain in the MtyRespira Supabase boundary, not Core DB.
+
+## 6. Functional requirements
+
+### FR1 — Public city reading
+
+The app must let a user consult available air-quality readings for supported Monterrey-area cities.
+
+### FR2 — AQI state presentation
+
+The app must present AQI and status using the shared AQI interpretation rules. Missing AQI must not become a normal AQI `0`.
+
+### FR3 — Main pollutant presentation
+
+The app may present the main pollutant when available. Missing pollutant data must degrade to `N/D` or equivalent unknown copy, not invented values.
+
+### FR4 — Measurement freshness
+
+The app must use `reading_timestamp` as the source for environmental measurement freshness.
+
+### FR5 — Pipeline traceability
+
+The app may show `last_successful_update_at` as pipeline traceability, but it must not treat that timestamp as the measurement time.
+
+### FR6 — Degraded states
+
+The app must communicate degraded, stale, old, unknown, or unavailable states explicitly when the data contract is incomplete or stale.
+
+### FR7 — Shared contract consumption
+
+The frontend must consume environmental readings through `get_latest_air_quality_per_city` unless an architecture decision explicitly changes that contract.
+
+### FR8 — City identity
+
+The product must reconcile cities by `city_id` where available, not by display names.
+
+### FR9 — Historical readings
+
+Historical air-quality views must not invent missing series, timestamps, pollutants, or AQI values.
+
+### FR10 — Geolocation
+
+Geolocation UX must preserve the supported-area boundary and must not imply coverage outside the product scope unless explicitly implemented.
+
+### FR11 — Provider continuity
+
+Provider continuity work must classify upstream failures and maintain honest public states without adding unverified fallback providers.
+
+### FR12 — Documentation governance
+
+Changes that affect runtime, contract, freshness, provider, or public claims must update the relevant canonical docs in the same PR or explicitly document the gap.
+
+## 7. Non-functional requirements
+
+### NFR1 — Honesty of freshness
+
+The product must not use “tiempo real” as a promise unless the runtime can truly support that meaning. Current copy should use honest language such as “lecturas disponibles”, “medición reportada”, or “actualización por pipeline horario”.
+
+### NFR2 — Data integrity
+
+The product must fail closed when data is missing, stale, null, malformed, or contract-uncertain.
+
+### NFR3 — Security
+
+The frontend must never include service-role keys, provider API keys, or privileged secrets.
+
+### NFR4 — Static deploy compatibility
+
+The public app must remain compatible with a static Vite frontend deployment unless architecture is explicitly revised.
+
+### NFR5 — Contract stability
+
+The RPC `get_latest_air_quality_per_city` must not be renamed, removed, or semantically changed without a coordinated rollout.
+
+### NFR6 — Cross-repo safety
+
+Any environmental data change must consider app, pipeline, Supabase/RPC, and UX together.
+
+### NFR7 — Documentation traceability
+
+README and docs must not present legacy providers, Buildship, Netlify, or obsolete runtime paths as current truth.
+
+## 8. Out of scope
+
+Out of scope for this brownfield stabilization phase:
+
+- User authentication.
+- Personalized alerts.
+- National expansion.
+- New unsupported cities.
+- Forecasting.
+- Gamification.
+- New environmental providers without contract work.
+- Core DB as a store for environmental readings.
+- Public dashboards for internal product telemetry.
+- Any service-role usage in the frontend.
+
+## 9. Open risks
+
+- Provider continuity still needs explicit readiness work after this docs baseline.
+- Runtime/provider docs may still drift between `monterrey-respira` and `airquality_pipeline`.
+- The exact production provider state must be verified against pipeline runtime before public claims are updated beyond this baseline.
+- RPC SQL/grants/nullability may still need direct Supabase verification.
+- Some historical docs may still include legacy references that need cleanup in later stories.
+
+## 10. Relationship to roadmap
+
+This PRD supports the roadmap in `docs/roadmap.md`.
+
+Current gate:
+
+- Story 1.1: completed when PR evidence confirms RPC contract smoke/runtime nullability.
+- Story 1.2: completed when PR evidence confirms Freshness Truth UX guard.
+- Story 1.2.1: this canonical documentation baseline.
+- Story 1.3: Provider Continuity Readiness must remain blocked until Story 1.2.1 is merged.
+
+## 11. Source of truth
+
+When there is drift, use this order:
+
+1. Runtime/workflow evidence for production behavior.
+2. `docs/shared-data-contract.md` for shared data semantics.
+3. `docs/PRD.md` for product scope.
+4. `docs/architecture.md` for architecture of record.
+5. `docs/roadmap.md` for story order.
+6. `AGENTS.md` for agent execution rules.
+7. README for contributor orientation.
+
+Do not use stale README claims as product truth when they conflict with the contract or freshness docs.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,7 +1,7 @@
 # Roadmap — MtyRespira
 
-Estado: brownfield operativo
-Fecha: 2026-05-13
+Estado: brownfield operativo  
+Fecha: 2026-05-21
 
 ## Cambio de curso
 
@@ -14,9 +14,22 @@ El roadmap vigente se ordena alrededor de cuatro principios:
 3. Degradación explícita.
 4. Continuidad de pipeline y proveedor.
 
+## Gate documental vigente
+
+Story 1.3 — Provider Continuity Readiness queda bloqueada hasta que Story 1.2.1 — Canonical Project Docs Stop esté aprobada y mergeada.
+
+Razón:
+
+- El repo necesitaba `AGENTS.md` raíz.
+- El repo necesitaba PRD canónico o decisión explícita.
+- README aún contenía lenguaje de “tiempo real” incompatible con Freshness Truth UX.
+- La arquitectura y roadmap existían, pero faltaba un índice/fuente de verdad para evitar drift.
+
 ## Fase 1 — Blindaje crítico
 
 ### Story 1.1 — RPC Contract Smoke + Runtime Nullability Verification
+
+Estado: completada si existe PR merged con evidencia de smoke/nullability.
 
 Objetivo: crear evidencia repetible de lo que devuelve `get_latest_air_quality_per_city`.
 
@@ -35,6 +48,8 @@ Criterio de salida:
 
 ### Story 1.2 — Freshness Truth UX + Stale Data Guard
 
+Estado: completada por PR #23 — `feat: add freshness truth UX guard`.
+
 Objetivo: evitar que la app comunique datos viejos como si fueran frescos.
 
 Alcance:
@@ -48,12 +63,40 @@ Criterio de salida:
 - La UI no sobrepromete frescura.
 - Un dato viejo o dudoso entra en estado explícito, no normal.
 
+### Story 1.2.1 — Canonical Project Docs Stop: PRD + Architecture + Roadmap + AGENTS Baseline
+
+Estado: en curso.
+
+Objetivo: crear o normalizar los documentos mínimos que gobiernan el proyecto antes de seguir con historias de implementación.
+
+Alcance:
+
+- Crear `AGENTS.md` en raíz.
+- Crear `docs/PRD.md` si falta PRD canónico.
+- Confirmar `docs/architecture.md` como arquitectura canónica sin duplicar `docs/ARCHITECTURE.md`.
+- Confirmar `docs/roadmap.md` como roadmap canónico sin duplicar `docs/ROADMAP.md`.
+- Limpiar README para no prometer “tiempo real”.
+- Crear `docs/DOCUMENTATION_INDEX.md` si ayuda a explicar fuente de verdad.
+- Registrar en Notion que Story 1.3 queda bloqueada hasta merge.
+
+Criterio de salida:
+
+- Existe `AGENTS.md` en raíz.
+- Existe PRD canónico.
+- Existe architecture canónica o decisión explícita de ruta.
+- Existe roadmap canónico o decisión explícita de ruta.
+- README ya no promete “tiempo real”.
+- No hay cambios runtime, Supabase, RPC ni pipeline.
+
 ### Story 1.3 — Provider Continuity Readiness
+
+Estado: bloqueada hasta merge de Story 1.2.1.
 
 Objetivo: preparar fallas del proveedor activo sin romper la experiencia pública.
 
 Alcance:
 
+- Verificar proveedor activo contra `airquality_pipeline`, no contra memoria o README legacy.
 - Clasificar errores upstream.
 - Registrar estado por ciudad.
 - Documentar runbook de contingencia.
@@ -121,9 +164,12 @@ Solo después de cerrar Fase 1:
 - Gamificación.
 - Nuevas lecturas ambientales fuera del contrato actual.
 
-## Documentos relacionados
+## Documentos canónicos relacionados
 
-- `docs/shared-data-contract.md`
-- `docs/data-pipeline.md`
+- `AGENTS.md`
+- `docs/DOCUMENTATION_INDEX.md`
+- `docs/PRD.md`
 - `docs/architecture.md`
+- `docs/shared-data-contract.md`
+- `docs/freshness-truth-ux.md`
 - `docs/blindaje-y-cambio-de-curso.md`


### PR DESCRIPTION
## Resumen

Crea el baseline documental canónico mínimo para MtyRespira antes de avanzar a Story 1.3 Provider Continuity Readiness.

## Por qué

El repo tenía roadmap, arquitectura, contrato compartido, mapa de blindaje y Freshness Truth UX, pero faltaban piezas de gobierno documental:

- `AGENTS.md` raíz.
- `docs/PRD.md` canónico.
- Índice documental/fuente de verdad.
- README alineado con Freshness Truth UX.
- Roadmap con gate explícito antes de Story 1.3.

## Cambios

- Agrega `AGENTS.md`.
- Agrega `docs/PRD.md`.
- Agrega `docs/DOCUMENTATION_INDEX.md`.
- Actualiza `docs/roadmap.md` para insertar Story 1.2.1 como gate.
- Actualiza `README.md` para orientar el producto como lecturas disponibles y medición reportada, sin sobreprometer frescura.

## Fuente de verdad final

- `AGENTS.md`
- `docs/PRD.md`
- `docs/architecture.md`
- `docs/roadmap.md`
- `docs/shared-data-contract.md`
- `docs/freshness-truth-ux.md`
- `docs/blindaje-y-cambio-de-curso.md`
- `README.md` como orientación pública.

## Validación

- Cambio documental únicamente.
- Diff contra `main`: 5 archivos.
- No se modificó código de app.
- No se modificó pipeline.
- No se modificó Supabase ni RPC.
- No se requiere build por no tocar runtime.

## Riesgos / pendientes

- Story 1.3 debe verificar proveedor activo contra `airquality_pipeline` antes de cualquier claim operativo.
- Cualquier cleanup histórico restante queda para Story 2.1.

## Rollback

Revertir este PR.