### PR TITLE
docs: reconcile provider state and roadmap after Story 1.3

### DIFF
--- a/docs/DOCUMENTATION_INDEX.md
+++ b/docs/DOCUMENTATION_INDEX.md
@@ -17,10 +17,21 @@ MtyRespira must remain scoped to the public air-quality product for Monterrey. D
 | `docs/PRD.md` | Product requirements baseline | Defines product scope, users, requirements, out-of-scope items, and current gate. |
 | `docs/architecture.md` | Architecture of record | Canonical architecture file. Keep lowercase path to avoid duplicate drift. |
 | `docs/roadmap.md` | Roadmap of record | Canonical story order and stop/gates. Keep lowercase path to avoid duplicate drift. |
-| `docs/shared-data-contract.md` | Shared data contract | Canonical boundary for `pipeline -> Supabase/RPC -> frontend`. |
+| `docs/shared-data-contract.md` | Shared data contract | Canonical boundary for `provider -> pipeline -> Supabase/RPC -> frontend`. |
 | `docs/freshness-truth-ux.md` | Freshness UX semantics | Canonical copy/threshold rules for measurement freshness. |
 | `docs/blindaje-y-cambio-de-curso.md` | Risk posture | Premortem-derived guardrails and change-of-course map. |
 | `README.md` | Public contributor orientation | Must stay honest, but is not the deepest source of truth. |
+
+## Cross-repo operational references
+
+These docs live in `elelier/airquality_pipeline` and are operational references, not duplicated app docs:
+
+| Document | Role | Notes |
+| --- | --- | --- |
+| `docs/provider-continuity-readiness.md` | Provider continuity baseline | Confirms WAQI/AQICN as active provider, AirVisual/IQAir as legacy/fallback, and provider failure taxonomy. |
+| `docs/provider-continuity-runbook.md` | Provider incident runbook | Triage guide for scheduled pipeline failures, stale public readings, city update failures, and manual recovery decisions. |
+| `.github/workflows/air-quality-workflow.yml` | Workflow evidence | Confirms hourly schedule, provider dispatch options, and read-only RPC health mode. |
+| `main.py` / `waqi_api.py` / `airvisual_api.py` | Runtime evidence | Confirms provider selection, WAQI station registry, and legacy AirVisual adapter behavior. |
 
 ## Explicit canonical path decisions
 
@@ -42,21 +53,23 @@ When files disagree:
 5. `docs/roadmap.md`.
 6. `docs/freshness-truth-ux.md`.
 7. `docs/blindaje-y-cambio-de-curso.md`.
-8. `README.md`.
+8. README.
+9. Pipeline provider continuity docs for incident/runbook detail.
 
 ## Drift cleanup rules
 
 Any mention of these terms must be reviewed before merge:
 
 ```bash
-rg "tiempo real|AirVisual|Buildship|Netlify|service_role|Core DB" README.md docs AGENTS.md
+rg "tiempo real|AirVisual|IQAir|WAQI|AQICN|Buildship|Netlify|service_role|Core DB" README.md docs AGENTS.md
 ```
 
 Allowed appearances:
 
-- Legacy context clearly marked as legacy.
+- Legacy context clearly marked as legacy/fallback.
 - Prohibitions or security rules.
 - Provider state that is explicitly tied to current runtime evidence.
+- WAQI/AQICN references as active provider when sourced from pipeline evidence.
 - Core DB clarification that it is not used for environmental readings.
 
 Disallowed appearances:
@@ -65,7 +78,12 @@ Disallowed appearances:
 - Buildship/Netlify as active runtime if current evidence says otherwise.
 - `service_role` in frontend guidance.
 - Core DB as storage for environmental readings.
+- AirVisual/IQAir as active provider when current pipeline evidence says WAQI/AQICN is active.
 
 ## Current gate
 
-Story 1.3 — Provider Continuity Readiness remains blocked until Story 1.2.1 — Canonical Project Docs Stop is merged.
+Story 1.2.1 — Canonical Project Docs Stop is completed by PR #24.
+
+Story 1.3 — Provider Continuity Readiness is completed by PR #14 in `elelier/airquality_pipeline`.
+
+Story 1.4 — Public Runtime Verification Gate is the next recommended Fase 1 story after Story 1.3.1 closes.

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -28,11 +28,13 @@ Current shared data concepts:
 - Critical RPC: `get_latest_air_quality_per_city`.
 - Public app hosting target: Cloudflare Pages.
 - Current public app URL: `https://mtyrespira.elelier.com/`.
+- Active provider: WAQI/AQICN, confirmed by pipeline docs/runtime configuration.
+- Legacy/fallback provider: IQAir/AirVisual, only for explicit controlled fallback when access is healthy.
 
 Canonical data flow:
 
 ```text
-provider -> airquality_pipeline -> Supabase tables -> get_latest_air_quality_per_city -> frontend -> public UX
+provider (WAQI/AQICN active; AirVisual/IQAir legacy/fallback) -> airquality_pipeline -> Supabase tables -> get_latest_air_quality_per_city -> frontend -> public UX
 ```
 
 ## 3. Objective for this brownfield phase
@@ -48,6 +50,7 @@ The product must evolve without breaking:
 - The public app.
 - The hourly producer assumptions.
 - The distinction between measurement time and pipeline update time.
+- The distinction between active provider and legacy/fallback adapters.
 
 ## 4. Users
 
@@ -74,8 +77,9 @@ Operational success:
 
 - The project has canonical docs for PRD, architecture, roadmap, and agent rules.
 - Future stories follow the documented roadmap instead of being invented from memory.
-- Provider continuity work does not begin until this baseline is merged.
+- Provider continuity is documented and runbook-ready in `elelier/airquality_pipeline`.
 - Runtime claims in README and docs do not contradict Freshness Truth UX.
+- Story 1.4 can verify runtime public behavior after this documentation reconciliation.
 
 Technical success:
 
@@ -84,6 +88,7 @@ Technical success:
 - `last_successful_update_at` remains pipeline traceability, not measurement freshness.
 - No frontend code uses service-role credentials.
 - Environmental readings remain in the MtyRespira Supabase boundary, not Core DB.
+- The frontend contract remains provider-agnostic and based on normalized Supabase/RPC fields.
 
 ## 6. Functional requirements
 
@@ -130,6 +135,8 @@ Geolocation UX must preserve the supported-area boundary and must not imply cove
 ### FR11 — Provider continuity
 
 Provider continuity work must classify upstream failures and maintain honest public states without adding unverified fallback providers.
+
+Current status: requirement documented/runbook-ready by PR #14 in `elelier/airquality_pipeline`. Remaining work is runtime public verification, not a blocker for provider docs readiness.
 
 ### FR12 — Documentation governance
 
@@ -182,22 +189,24 @@ Out of scope for this brownfield stabilization phase:
 
 ## 9. Open risks
 
-- Provider continuity still needs explicit readiness work after this docs baseline.
-- Runtime/provider docs may still drift between `monterrey-respira` and `airquality_pipeline`.
-- The exact production provider state must be verified against pipeline runtime before public claims are updated beyond this baseline.
-- RPC SQL/grants/nullability may still need direct Supabase verification.
+- Runtime public verification still needs explicit evidence after documentation/provider-state reconciliation.
+- RPC SQL/grants/nullability may still need direct Supabase verification if not fully closed by prior smoke evidence.
 - Some historical docs may still include legacy references that need cleanup in later stories.
+- WAQI/AQICN availability, token health, and station mapping remain operational risks.
+- AirVisual/IQAir must not be treated as a normal fallback while access is unproven or unhealthy.
 
 ## 10. Relationship to roadmap
 
 This PRD supports the roadmap in `docs/roadmap.md`.
 
-Current gate:
+Current gate/status:
 
 - Story 1.1: completed when PR evidence confirms RPC contract smoke/runtime nullability.
-- Story 1.2: completed when PR evidence confirms Freshness Truth UX guard.
-- Story 1.2.1: this canonical documentation baseline.
-- Story 1.3: Provider Continuity Readiness must remain blocked until Story 1.2.1 is merged.
+- Story 1.2: completed by PR #23 — `feat: add freshness truth UX guard`.
+- Story 1.2.1: completed by PR #24 — `docs: add canonical MtyRespira project docs baseline`.
+- Story 1.3: completed by PR #14 in `elelier/airquality_pipeline` — `docs: add provider continuity readiness runbook`.
+- Story 1.3.1: reconciles app docs with the post-PR #14 provider state.
+- Story 1.4: next recommended gate — Public Runtime Verification Gate.
 
 ## 11. Source of truth
 
@@ -210,5 +219,6 @@ When there is drift, use this order:
 5. `docs/roadmap.md` for story order.
 6. `AGENTS.md` for agent execution rules.
 7. README for contributor orientation.
+8. Provider continuity docs in `elelier/airquality_pipeline` for operational runbook details.
 
 Do not use stale README claims as product truth when they conflict with the contract or freshness docs.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -23,17 +23,25 @@ El target operativo actual del frontend es Cloudflare Pages. Cualquier referenci
 - La RPC `get_latest_air_quality_per_city` es un contrato crítico de producto.
 - No introducir runtime server-side para el flujo público principal.
 - No inventar datos cuando el contrato falle; degradar de forma explícita.
+- No usar un fallback de proveedor que no esté explícitamente seleccionado, sano y documentado.
 
 ## Flujo end-to-end vigente
 
 ```text
-AirVisual / IQAir
+WAQI/AQICN active provider
   -> airquality_pipeline GitHub Actions
   -> Supabase tables: cities, air_quality_readings
   -> Supabase RPC: get_latest_air_quality_per_city
   -> monterrey-respira frontend
   -> mtyrespira.elelier.com
 ```
+
+Provider state:
+
+- WAQI/AQICN es el proveedor activo confirmado por el pipeline.
+- `AIR_QUALITY_PROVIDER=waqi` es el default de runtime del pipeline.
+- IQAir/AirVisual existe como adapter legacy/fallback y solo debe usarse si se selecciona explícitamente, se confirma sano y se opera como rollback/control recovery.
+- No existe un proveedor oculto en el flujo vigente.
 
 ## Frontend
 
@@ -66,7 +74,7 @@ El frontend consume Supabase mediante variables públicas con prefijo `VITE_`:
 - `VITE_SUPABASE_URL`
 - `VITE_SUPABASE_ANON_KEY`
 
-No debe usar claves privilegiadas como `SUPABASE_SERVICE_ROLE_KEY` ni `AIRVISUAL_API_KEY`.
+No debe usar claves privilegiadas como `SUPABASE_SERVICE_ROLE_KEY`, `WAQI_API_TOKEN` ni `AIRVISUAL_API_KEY`.
 
 ## Pipeline backend
 
@@ -79,17 +87,20 @@ Workflow vigente:
 - Runtime: Python 3.11
 - Runner: `windows-latest`
 - Ejecuta `pytest` antes de `main.py`
+- `workflow_dispatch.provider` permite `waqi` o `airvisual`, default `waqi`
 
 Responsabilidades:
 
-- Obtener ciudades disponibles desde AirVisual.
-- Leer ciudades existentes desde Supabase.
-- Sincronizar altas/desactivaciones.
-- Evaluar si cada ciudad necesita actualización.
+- Usar WAQI/AQICN por default mediante `AIR_QUALITY_PROVIDER=waqi`.
+- Conservar las ciudades existentes en Supabase cuando el provider activo es WAQI.
+- Usar mapeo explícito ciudad -> estación WAQI para las ciudades activas esperadas.
+- Rechazar payloads sin AQI, sin timestamp, sin coordenadas válidas o fuera de Nuevo León.
+- Evaluar si cada ciudad necesita actualización según `last_successful_update_at` y el intervalo operativo.
 - Consultar datos de calidad del aire.
 - Validar payload antes de insertar.
-- Insertar lecturas en `air_quality_readings`.
+- Insertar lecturas válidas en `air_quality_readings`.
 - Actualizar estado operativo en `cities`.
+- Usar AirVisual/IQAir solo si `AIR_QUALITY_PROVIDER=airvisual` se selecciona explícitamente y el acceso está sano.
 
 ## Supabase y contrato compartido
 
@@ -97,6 +108,7 @@ Tablas compartidas:
 
 - `cities`
 - `air_quality_readings`
+- `pipeline_logs` cuando aplique
 
 RPC crítica:
 
@@ -110,6 +122,7 @@ Reglas:
 - Reconciliar ciudades por `city_id`, no por nombre.
 - Tratar `reading_timestamp` como tiempo de medición.
 - Tratar `last_successful_update_at` como tiempo de éxito del pipeline.
+- No hacer depender el contrato frontend de que el proveedor sea AirVisual, WAQI u otro proveedor específico.
 
 El contrato detallado vive en:
 
@@ -172,5 +185,6 @@ Cambios de contrato:
 
 - SQL exacto, grants y nullability runtime de la RPC aún requieren validación directa en Supabase.
 - La configuración exacta de Cloudflare Pages puede no estar expresada como IaC dentro del repo.
-- La continuidad de proveedor upstream debe tratarse como riesgo operativo de producto.
+- WAQI/AQICN depende de disponibilidad upstream, token y estación mapeada por ciudad.
+- AirVisual/IQAir no debe tratarse como fallback operativo normal si el acceso no está probado sano.
 - Falta automatizar un smoke test canónico real contra la RPC en entorno controlado.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -14,16 +14,21 @@ El roadmap vigente se ordena alrededor de cuatro principios:
 3. Degradación explícita.
 4. Continuidad de pipeline y proveedor.
 
-## Gate documental vigente
+## Estado documental vigente
 
-Story 1.3 — Provider Continuity Readiness queda bloqueada hasta que Story 1.2.1 — Canonical Project Docs Stop esté aprobada y mergeada.
+Story 1.2.1 — Canonical Project Docs Stop quedó completada por PR #24 — `docs: add canonical MtyRespira project docs baseline`.
+
+Story 1.3 — Provider Continuity Readiness quedó completada en el repo de pipeline por PR #14 — `docs: add provider continuity readiness runbook`.
+
+El roadmap queda desbloqueado para Story 1.4 — Public Runtime Verification Gate como la siguiente historia lógica de Fase 1.
 
 Razón:
 
-- El repo necesitaba `AGENTS.md` raíz.
-- El repo necesitaba PRD canónico o decisión explícita.
-- README aún contenía lenguaje de “tiempo real” incompatible con Freshness Truth UX.
-- La arquitectura y roadmap existían, pero faltaba un índice/fuente de verdad para evitar drift.
+- El repo app ya cuenta con `AGENTS.md` raíz.
+- El repo app ya cuenta con PRD, arquitectura, roadmap e índice documental canónicos.
+- README ya no promete “tiempo real”.
+- El pipeline ya documentó WAQI/AQICN como proveedor activo y AirVisual/IQAir como legacy/fallback explícito.
+- La siguiente necesidad crítica es verificar runtime público, workflow horario y contrato después de cambios relevantes.
 
 ## Fase 1 — Blindaje crítico
 
@@ -65,48 +70,74 @@ Criterio de salida:
 
 ### Story 1.2.1 — Canonical Project Docs Stop: PRD + Architecture + Roadmap + AGENTS Baseline
 
-Estado: en curso.
+Estado: completada por PR #24 — `docs: add canonical MtyRespira project docs baseline`.
 
 Objetivo: crear o normalizar los documentos mínimos que gobiernan el proyecto antes de seguir con historias de implementación.
 
-Alcance:
+Alcance completado:
 
 - Crear `AGENTS.md` en raíz.
-- Crear `docs/PRD.md` si falta PRD canónico.
+- Crear `docs/PRD.md` como PRD canónico.
 - Confirmar `docs/architecture.md` como arquitectura canónica sin duplicar `docs/ARCHITECTURE.md`.
 - Confirmar `docs/roadmap.md` como roadmap canónico sin duplicar `docs/ROADMAP.md`.
 - Limpiar README para no prometer “tiempo real”.
-- Crear `docs/DOCUMENTATION_INDEX.md` si ayuda a explicar fuente de verdad.
-- Registrar en Notion que Story 1.3 queda bloqueada hasta merge.
+- Crear `docs/DOCUMENTATION_INDEX.md` como índice/fuente de verdad.
 
 Criterio de salida:
 
 - Existe `AGENTS.md` en raíz.
 - Existe PRD canónico.
-- Existe architecture canónica o decisión explícita de ruta.
-- Existe roadmap canónico o decisión explícita de ruta.
+- Existe architecture canónica.
+- Existe roadmap canónico.
 - README ya no promete “tiempo real”.
-- No hay cambios runtime, Supabase, RPC ni pipeline.
+- No hubo cambios runtime, Supabase, RPC ni pipeline en el repo app.
 
 ### Story 1.3 — Provider Continuity Readiness
 
-Estado: bloqueada hasta merge de Story 1.2.1.
+Estado: completada por PR #14 en `elelier/airquality_pipeline` — `docs: add provider continuity readiness runbook`.
 
 Objetivo: preparar fallas del proveedor activo sin romper la experiencia pública.
 
-Alcance:
+Alcance completado:
 
 - Verificar proveedor activo contra `airquality_pipeline`, no contra memoria o README legacy.
-- Clasificar errores upstream.
-- Registrar estado por ciudad.
+- Documentar WAQI/AQICN como provider activo.
+- Documentar AirVisual/IQAir como provider legacy/fallback, no activo.
+- Confirmar `AIR_QUALITY_PROVIDER=waqi` como default.
+- Confirmar `workflow_dispatch` con opciones `waqi` / `airvisual`.
+- Documentar taxonomía de errores upstream.
 - Documentar runbook de contingencia.
 - Evitar fallback productivo no verificado.
 
 Criterio de salida:
 
 - El equipo puede distinguir error upstream, dato viejo, ciudad sin update y estado sano.
+- Existe runbook operativo de continuidad en `airquality_pipeline`.
+
+### Story 1.3.1 — App Docs Provider State Reconciliation + Roadmap Unlock
+
+Estado: en curso por esta historia documental.
+
+Objetivo: reconciliar los documentos canónicos del repo app con el estado real post-PR #14 del pipeline.
+
+Alcance:
+
+- Desbloquear roadmap post Story 1.3.
+- Alinear arquitectura a WAQI/AQICN como provider activo.
+- Alinear contrato compartido a provider genérico con WAQI/AQICN activo y AirVisual/IQAir legacy/fallback.
+- Alinear PRD e índice documental con el estado post-PR #14.
+
+Criterio de salida:
+
+- ROADMAP no deja Story 1.2.1 como en curso.
+- ROADMAP no deja Story 1.3 como bloqueada.
+- Architecture no presenta AirVisual/IQAir como provider activo.
+- Shared data contract no congela el boundary como AirVisual-only.
+- Story 1.4 queda como siguiente gate recomendado.
 
 ### Story 1.4 — Public Runtime Verification Gate
+
+Estado: siguiente historia recomendada después de cerrar Story 1.3.1.
 
 Objetivo: verificar producción después de cambios relevantes.
 
@@ -173,3 +204,5 @@ Solo después de cerrar Fase 1:
 - `docs/shared-data-contract.md`
 - `docs/freshness-truth-ux.md`
 - `docs/blindaje-y-cambio-de-curso.md`
+- `elelier/airquality_pipeline/docs/provider-continuity-readiness.md`
+- `elelier/airquality_pipeline/docs/provider-continuity-runbook.md`

--- a/docs/shared-data-contract.md
+++ b/docs/shared-data-contract.md
@@ -4,7 +4,9 @@ Status: Brownfield baseline
 
 This document freezes the shared product boundary for MtyRespira:
 
-`AirVisual -> airquality_pipeline -> Supabase tables -> RPC -> monterrey-respira frontend`
+`provider (WAQI/AQICN active; AirVisual/IQAir legacy/fallback) -> airquality_pipeline -> Supabase tables -> RPC -> monterrey-respira frontend`
+
+The contract is intentionally provider-agnostic from the frontend perspective. The frontend must consume normalized Supabase/RPC fields and must not depend on AirVisual-only, WAQI-only, or provider-specific payload internals.
 
 ## Source of truth hierarchy
 
@@ -13,7 +15,8 @@ When implementation, docs, tests, and runtime disagree, use this order:
 1. Effective workflow behavior in `airquality_pipeline/.github/workflows/air-quality-workflow.yml`
 2. This document
 3. Producer and consumer code
-4. Supporting docs such as `docs/data-pipeline.md` and `docs/architecture.md`
+4. Supporting docs such as `docs/architecture.md`
+5. Provider continuity docs in `elelier/airquality_pipeline/docs/provider-continuity-readiness.md` and `elelier/airquality_pipeline/docs/provider-continuity-runbook.md`
 
 ## Repos involved
 
@@ -26,9 +29,23 @@ When implementation, docs, tests, and runtime disagree, use this order:
 - `elelier/airquality_pipeline`
   - Producer paths:
     - `main.py`
+    - `waqi_api.py`
+    - `airvisual_api.py`
     - `update_city.py`
     - `utils.py`
     - `.github/workflows/air-quality-workflow.yml`
+
+## Provider boundary
+
+Runtime provider state confirmed by the pipeline:
+
+- WAQI/AQICN is the active provider.
+- `AIR_QUALITY_PROVIDER=waqi` is the default.
+- WAQI uses existing Supabase cities and explicit city -> station mapping.
+- AirVisual/IQAir is a legacy/fallback adapter only; it is not the active provider.
+- `workflow_dispatch.provider` can explicitly select `waqi` or `airvisual` for controlled manual runs.
+
+Contract rule: provider-specific ingestion can change only through a coordinated pipeline/contract rollout. The frontend contract remains the normalized Supabase/RPC payload, not the upstream provider response.
 
 ## Critical latest RPC
 
@@ -253,7 +270,7 @@ The daily history RPC returns rows ordered by `reading_date` ascending:
 | --- | --- | --- | --- |
 | `city_id` | `number` | required | Stable identity key. |
 | `city_name` | `string` | required | Display label from RPC. |
-| `api_name` | `string` | required | Upstream API naming value. |
+| `api_name` | `string` | required | Upstream/provider naming value normalized through Supabase. |
 | `latitude` | `number \| null` | nullable | Frontend falls back to static city coordinates if null. |
 | `longitude` | `number \| null` | nullable | Frontend falls back to static city coordinates if null. |
 | `reading_timestamp` | `string` | required | Source measurement time. Treat as UTC. |
@@ -293,7 +310,7 @@ Rules:
 
 ## Pollutant data limitation
 
-The current AirVisual integration exposes and stores AQI and dominant pollutant keys from `current.pollution` (`aqius`, `mainus`, `aqicn`, `maincn`, `ts`). It does not provide confirmed historical concentration series for PM2.5, PM10, O3, NO2, SO2, or CO in the current contract.
+The current normalized contract exposes AQI and dominant pollutant keys from provider payloads. Under WAQI/AQICN, pollutant concentration availability is provider/station dependent and is not guaranteed by this frontend contract. Under legacy AirVisual/IQAir, historical concentration series are also not part of the current contract.
 
 Allowed:
 
@@ -321,6 +338,7 @@ Prohibited:
 - Do not label a client refresh as a new upstream measurement.
 - Do not match cities by name when `city_id` is available.
 - Do not fallback historical charts to random, mocked, or zero-filled series.
+- Do not switch to AirVisual/IQAir silently to mask WAQI/AQICN failure.
 
 ## Release checklist for contract-affecting changes
 
@@ -328,10 +346,10 @@ Before merge:
 
 - [ ] Validate `npm run lint` and `npm run build` for frontend changes.
 - [ ] Validate `pytest` for pipeline changes.
-- [ ] Check whether the change affects RPC shape, nullability, freshness, timestamps, cache, or city identity.
+- [ ] Check whether the change affects RPC shape, nullability, freshness, timestamps, cache, provider, or city identity.
 - [ ] Update this document if the shared contract changes.
 - [ ] Add or update fixture/smoke evidence for `get_latest_air_quality_per_city`.
-- [ ] Include rollback guidance when a change touches Supabase/RPC, pipeline, public deploy, or routing.
+- [ ] Include rollback guidance when a change touches Supabase/RPC, pipeline, public deploy, provider, or routing.
 
 After deploy:
 


### PR DESCRIPTION
## Resumen

Reconciles the canonical app docs with the post-Story 1.3 provider state documented in `elelier/airquality_pipeline` PR #14.

This is documentation-only. It updates provider state, roadmap status, and cross-repo references without changing runtime behavior.

## Challenge / básicos canónicos verificados

Verified before proceeding:

- `AGENTS.md`
- `docs/PRD.md`
- `docs/architecture.md`
- `docs/roadmap.md`

Because all canonical basics exist, Story 1.3.1 was allowed to continue. No STOP/base-docs story was needed.

## Estado post-PR #14

Pipeline evidence now treats:

- WAQI/AQICN as the active provider.
- `AIR_QUALITY_PROVIDER=waqi` as the default provider.
- `workflow_dispatch.provider` as an explicit `waqi` / `airvisual` selector.
- IQAir/AirVisual as legacy/fallback only, not active provider.
- No hidden provider as part of current runtime.

## Documentos actualizados

- `docs/roadmap.md`
  - Marks Story 1.2.1 completed by PR #24.
  - Marks Story 1.3 completed by PR #14 in `elelier/airquality_pipeline`.
  - Adds Story 1.3.1 as the reconciliation story.
  - Unlocks Story 1.4 — Public Runtime Verification Gate as the next recommended story.

- `docs/architecture.md`
  - Updates current end-to-end flow to WAQI/AQICN active provider.
  - Documents AirVisual/IQAir as legacy/fallback only.
  - Aligns pipeline responsibilities with WAQI default, Supabase city preservation, and explicit city -> WAQI station mapping.

- `docs/shared-data-contract.md`
  - Replaces AirVisual-only boundary with provider-generic boundary.
  - Clarifies that frontend contract depends on normalized Supabase/RPC fields, not provider-specific payloads.
  - Keeps existing fields, RPC names, SQL snippets, and compatibility rules.

- `docs/PRD.md`
  - Updates current system baseline and roadmap relationship.
  - Marks FR11 Provider continuity as documented/runbook-ready rather than pending blocker.
  - Keeps runtime public verification and RPC live validation as open risks where applicable.

- `docs/DOCUMENTATION_INDEX.md`
  - Adds pipeline provider continuity docs as cross-repo operational references.
  - Updates drift search terms and current gate state.

README was reviewed and not changed because it already avoids promising real-time monitoring and does not name AirVisual/IQAir as the active provider.

## Impacto por área

- app: docs only; no frontend runtime changes.
- pipeline: read-only reference only; no pipeline files changed.
- BD MtyRespira: no writes, no schema changes.
- Supabase RPC: no SQL/RPC changes.
- UX: copy/expectations in docs only; no UI runtime changes.
- Cloudflare: no deploy/config changes.

## Validación

- Confirmed branch diff is docs-only: 5 files under `docs/`.
- Reviewed relative references to app docs and pipeline docs.
- Reviewed README and left unchanged because it is already honest about freshness.
- Documented equivalent search for:

```bash
rg "tiempo real|AirVisual|IQAir|WAQI|AQICN|Buildship|Netlify|service_role|Core DB" README.md docs AGENTS.md
```

Allowed remaining appearances are provider-state, legacy/fallback context, explicit prohibitions/security language, or Core DB exclusion from environmental readings.

No `npm run build` was run because this PR changes documentation only and no runtime/frontend files.

## Riesgos / pendientes

- Story 1.4 should verify public runtime behavior, hourly workflow state, and at least one known city payload after this doc reconciliation.
- RPC SQL/grants/nullability remain open if not already fully closed by prior smoke evidence.
- Historical legacy drift may still exist outside canonical docs and can be cleaned in a future docs drift story if discovered.

## Siguiente historia recomendada

Story 1.4 — Public Runtime Verification Gate.

Recommended scope:

- Verify `https://mtyrespira.elelier.com`.
- Verify latest `airquality_pipeline` hourly workflow behavior.
- Verify a known city payload against `get_latest_air_quality_per_city` contract.
- Record public runtime evidence without writing live data unless explicitly required.

## Rollback

Revert this documentation PR. Runtime, Supabase, RPC, provider behavior, and Cloudflare config are untouched.