### PR TITLE
docs: add public runtime verification gate

### DIFF
--- a/docs/DOCUMENTATION_INDEX.md
+++ b/docs/DOCUMENTATION_INDEX.md
@@ -20,6 +20,7 @@ MtyRespira must remain scoped to the public air-quality product for Monterrey. D
 | `docs/shared-data-contract.md` | Shared data contract | Canonical boundary for `provider -> pipeline -> Supabase/RPC -> frontend`. |
 | `docs/freshness-truth-ux.md` | Freshness UX semantics | Canonical copy/threshold rules for measurement freshness. |
 | `docs/blindaje-y-cambio-de-curso.md` | Risk posture | Premortem-derived guardrails and change-of-course map. |
+| `docs/public-runtime-verification-gate.md` | Runtime verification gate | Minimum safe QA/docs gate for public app, pipeline evidence, and RPC verification after relevant changes. |
 | `README.md` | Public contributor orientation | Must stay honest, but is not the deepest source of truth. |
 
 ## Cross-repo operational references
@@ -53,8 +54,9 @@ When files disagree:
 5. `docs/roadmap.md`.
 6. `docs/freshness-truth-ux.md`.
 7. `docs/blindaje-y-cambio-de-curso.md`.
-8. README.
-9. Pipeline provider continuity docs for incident/runbook detail.
+8. `docs/public-runtime-verification-gate.md` for post-change runtime evidence.
+9. README.
+10. Pipeline provider continuity docs for incident/runbook detail.
 
 ## Drift cleanup rules
 
@@ -71,10 +73,11 @@ Allowed appearances:
 - Provider state that is explicitly tied to current runtime evidence.
 - WAQI/AQICN references as active provider when sourced from pipeline evidence.
 - Core DB clarification that it is not used for environmental readings.
+- Runtime verification evidence or known-drift notes in `docs/public-runtime-verification-gate.md`.
 
 Disallowed appearances:
 
-- `tiempo real` as a product promise.
+- `tiempo real` as a product promise in docs or README.
 - Buildship/Netlify as active runtime if current evidence says otherwise.
 - `service_role` in frontend guidance.
 - Core DB as storage for environmental readings.
@@ -86,4 +89,6 @@ Story 1.2.1 — Canonical Project Docs Stop is completed by PR #24.
 
 Story 1.3 — Provider Continuity Readiness is completed by PR #14 in `elelier/airquality_pipeline`.
 
-Story 1.4 — Public Runtime Verification Gate is the next recommended Fase 1 story after Story 1.3.1 closes.
+Story 1.3.1 — App Docs Provider State Reconciliation + Roadmap Unlock is completed by PR #25.
+
+Story 1.4 — Public Runtime Verification Gate is the current Fase 1 QA/docs gate.

--- a/docs/public-runtime-verification-gate.md
+++ b/docs/public-runtime-verification-gate.md
@@ -1,0 +1,239 @@
+# Public Runtime Verification Gate — MtyRespira
+
+Status: Story 1.4 QA/docs baseline  
+Date: 2026-05-22  
+Scope: `elelier/monterrey-respira` with `elelier/airquality_pipeline` as read-only operational reference
+
+## 1. Purpose
+
+This gate defines the minimum safe verification required after documentation, runtime, provider, deploy, or contract-affecting changes.
+
+The goal is not to change production. The goal is to record enough evidence to know whether the public app, pipeline assumptions, and Supabase/RPC contract still agree.
+
+This gate protects against the highest-risk MtyRespira failure mode: the public site staying online while presenting old, missing, null, or incomplete environmental readings as fresh and trustworthy.
+
+## 2. Non-negotiables
+
+Do not use this gate to make runtime changes.
+
+Prohibited during this gate unless a future story explicitly authorizes it:
+
+- Do not push directly to `main`.
+- Do not change frontend runtime.
+- Do not change AQI, historical chart, geolocation, cache, or city-selection behavior.
+- Do not write to Supabase.
+- Do not modify SQL, grants, schema, tables, or RPCs.
+- Do not rename or replace `get_latest_air_quality_per_city`.
+- Do not expose secrets.
+- Do not use privileged database keys in the frontend/app.
+- Do not change provider runtime.
+- Do not change WAQI station mappings.
+- Do not run forced live ingestion as part of routine verification.
+- Do not silently switch from WAQI/AQICN to AirVisual/IQAir.
+
+## 3. Source-of-truth order
+
+Use this order when evidence conflicts:
+
+1. Current runtime/workflow evidence from `elelier/airquality_pipeline`.
+2. `docs/shared-data-contract.md`.
+3. `docs/PRD.md`.
+4. `docs/architecture.md`.
+5. `docs/roadmap.md`.
+6. `docs/freshness-truth-ux.md`.
+7. `docs/blindaje-y-cambio-de-curso.md`.
+8. README.
+
+## 4. Public app verification
+
+Verify the public app URL:
+
+- `https://mtyrespira.elelier.com/`
+
+Minimum checks:
+
+- The public page responds and loads a MtyRespira experience.
+- The visible experience does not present missing data as AQI `0`.
+- The visible experience distinguishes environmental measurement freshness from frontend refresh when those values are available.
+- The app does not claim a stronger freshness guarantee than the hourly producer cadence.
+- Degraded, stale, old, or missing states remain explicit.
+
+Evidence to capture in the PR:
+
+- Timestamp of verification.
+- URL checked.
+- Browser/tool used.
+- Any visible freshness/degradation state.
+- Any public copy or metadata drift found.
+
+### Current Story 1.4 observation
+
+A safe public fetch of `https://mtyrespira.elelier.com/` on 2026-05-22 returned the page title:
+
+```text
+MonterreyRespira - Calidad del Aire en Tiempo Real
+```
+
+This is public metadata/runtime copy, not a documentation claim. It should be treated as follow-up drift because the canonical docs prohibit using `tiempo real` as a product promise unless runtime can support that meaning.
+
+Do not fix this in this docs-only gate. Open a separate app runtime/SEO copy story if the team decides to remove that title claim.
+
+## 5. Documentation drift verification
+
+Run or document equivalent:
+
+```bash
+rg "tiempo real|AirVisual|IQAir|WAQI|AQICN|Buildship|Netlify|privileged database key|Core DB" README.md docs AGENTS.md
+```
+
+Allowed appearances:
+
+- `tiempo real` only as a prohibition, historical drift note, or explicit risk.
+- WAQI/AQICN as active provider when sourced from pipeline evidence.
+- AirVisual/IQAir only as legacy/fallback, not active provider.
+- Privileged database key wording only as security prohibition or pipeline-only secret context.
+- Core DB only as a clarification that it is not used for environmental readings.
+- Buildship/Netlify only as legacy context, not active runtime.
+
+Disallowed appearances:
+
+- `tiempo real` as public product promise in docs or README.
+- AirVisual/IQAir as active provider.
+- Core DB as storage for environmental readings.
+- Privileged database keys as app/frontend credentials.
+- Buildship/Netlify as current runtime.
+
+## 6. Pipeline read-only verification
+
+Use `elelier/airquality_pipeline` as read-only reference.
+
+Minimum files to inspect:
+
+- `README.md`
+- `.github/workflows/air-quality-workflow.yml`
+- `main.py`
+- `waqi_api.py`
+- `airvisual_api.py`
+- `update_city.py`
+- `utils.py`
+- `docs/provider-continuity-readiness.md`
+- `docs/provider-continuity-runbook.md`
+
+Expected workflow evidence:
+
+- Scheduled workflow exists with cron `0 * * * *`.
+- Normal scheduled provider defaults to `waqi`.
+- Manual provider selector allows only `waqi` and `airvisual`.
+- Read-only RPC health mode exists.
+- Pull requests run tests without writing live environmental data.
+
+Do not run the scheduled/write path from this gate.
+
+Safe checks:
+
+- Inspect the latest workflow configuration.
+- Inspect recent workflow status if GitHub Actions access is available.
+- Use the read-only RPC health mode only when an operator intentionally wants read-only RPC evidence.
+
+Unsafe checks:
+
+- Forced live ingestion.
+- Manual runs intended to insert readings unless a separate operations story authorizes it.
+
+## 7. Supabase/RPC read-only verification
+
+The critical RPC is:
+
+```ts
+supabase.rpc('get_latest_air_quality_per_city')
+```
+
+Preferred read-only evidence:
+
+- RPC responds successfully.
+- Response is an array.
+- At least one known supported city appears.
+- Each sampled row preserves expected fields from `docs/shared-data-contract.md`.
+- `reading_timestamp` remains the measurement timestamp.
+- `last_successful_update_at` remains pipeline traceability.
+- Nullable fields remain treated as nullable.
+
+If Supabase is not connected to the agent, do not guess. Record the blocker and ask an operator to run a read-only sample of `get_latest_air_quality_per_city` in Supabase.
+
+Manual reviewer should verify:
+
+- `city_id`
+- `city_name`
+- `api_name`
+- `reading_timestamp`
+- `aqi_us`
+- `main_pollutant_us`
+- `temperature_c`
+- `humidity_percent`
+- `wind_speed_ms`
+- `wind_direction_deg`
+- `weather_icon`
+- `last_successful_update_at`
+
+Do not change SQL, grants, schema, function body, RLS, or data as part of this gate.
+
+## 8. Pass / degraded / fail outcomes
+
+### Pass
+
+Use pass when:
+
+- Public app loads.
+- No public/docs freshness overpromise is found.
+- Pipeline read-only evidence still confirms WAQI/AQICN default.
+- RPC read-only evidence confirms expected shape.
+
+### Degraded pass
+
+Use degraded pass when:
+
+- Public app loads, but there is non-blocking copy/metadata drift.
+- Supabase/RPC cannot be checked by the agent, but a manual checklist is provided.
+- GitHub Actions recent runtime status is unavailable, but workflow config remains correct.
+
+### Fail
+
+Use fail when:
+
+- Public app is unavailable.
+- Runtime copy materially overpromises freshness.
+- Workflow config no longer defaults to WAQI/AQICN.
+- RPC shape changed or is unavailable.
+- Any data appears invented, zero-filled, or falsely fresh.
+
+## 9. Current Story 1.4 result
+
+Result: degraded pass.
+
+Evidence:
+
+- Public app URL responded on 2026-05-22.
+- Public metadata still includes `Calidad del Aire en Tiempo Real`; this is a follow-up runtime/SEO copy drift, not fixed here.
+- Pipeline workflow config confirms hourly schedule, default `waqi`, explicit `waqi` / `airvisual` dispatch options, and read-only RPC health mode.
+- No Supabase live query was executed from this agent session because no Supabase connector/tool was available here.
+- No runtime files were changed.
+- No pipeline files were changed.
+- No Supabase writes were performed.
+
+## 10. Follow-up recommendations
+
+Recommended next follow-up after this gate:
+
+1. Small app/SEO copy story to remove or soften public page title metadata containing `Tiempo Real` if confirmed in source.
+2. Manual or agent-enabled read-only Supabase RPC evidence capture for `get_latest_air_quality_per_city`.
+3. Fase 2 Story 2.1 — Docs Drift Cleanup only after the runtime/metadata copy issue is either accepted as known drift or corrected.
+
+## 11. Rollback
+
+This file is documentation only.
+
+Rollback:
+
+1. Revert the PR that added this file.
+2. Keep runtime unchanged.
+3. Re-open Story 1.4 if the removed evidence still needs to be captured.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -20,7 +20,9 @@ Story 1.2.1 — Canonical Project Docs Stop quedó completada por PR #24 — `do
 
 Story 1.3 — Provider Continuity Readiness quedó completada en el repo de pipeline por PR #14 — `docs: add provider continuity readiness runbook`.
 
-El roadmap queda desbloqueado para Story 1.4 — Public Runtime Verification Gate como la siguiente historia lógica de Fase 1.
+Story 1.3.1 — App Docs Provider State Reconciliation + Roadmap Unlock quedó completada por PR #25 — `docs: reconcile provider state and roadmap after Story 1.3`.
+
+Story 1.4 — Public Runtime Verification Gate queda como gate de verificación documental/QA en curso por esta historia.
 
 Razón:
 
@@ -116,11 +118,11 @@ Criterio de salida:
 
 ### Story 1.3.1 — App Docs Provider State Reconciliation + Roadmap Unlock
 
-Estado: en curso por esta historia documental.
+Estado: completada por PR #25 — `docs: reconcile provider state and roadmap after Story 1.3`.
 
 Objetivo: reconciliar los documentos canónicos del repo app con el estado real post-PR #14 del pipeline.
 
-Alcance:
+Alcance completado:
 
 - Desbloquear roadmap post Story 1.3.
 - Alinear arquitectura a WAQI/AQICN como provider activo.
@@ -137,7 +139,7 @@ Criterio de salida:
 
 ### Story 1.4 — Public Runtime Verification Gate
 
-Estado: siguiente historia recomendada después de cerrar Story 1.3.1.
+Estado: en curso por esta historia.
 
 Objetivo: verificar producción después de cambios relevantes.
 
@@ -151,6 +153,7 @@ Alcance:
 Criterio de salida:
 
 - Cada release relevante tiene evidencia mínima de app, pipeline y contrato.
+- Si falta acceso a Supabase/RPC o aparece drift de copy pública, se registra como degraded pass o follow-up explícito.
 
 ## Fase 2 — Limpieza y gobernanza
 
@@ -204,5 +207,6 @@ Solo después de cerrar Fase 1:
 - `docs/shared-data-contract.md`
 - `docs/freshness-truth-ux.md`
 - `docs/blindaje-y-cambio-de-curso.md`
+- `docs/public-runtime-verification-gate.md`
 - `elelier/airquality_pipeline/docs/provider-continuity-readiness.md`
 - `elelier/airquality_pipeline/docs/provider-continuity-runbook.md`


### PR DESCRIPTION
## Resumen

Adds Story 1.4 — Public Runtime Verification Gate as a documentation/QA baseline for MtyRespira.

This PR creates a repeatable, safe verification gate for public runtime checks, pipeline read-only evidence, and RPC verification expectations after relevant changes.

## Challenge / básicos canónicos verificados

Verified before proceeding:

- `AGENTS.md`
- `docs/PRD.md`
- `docs/architecture.md`
- `docs/roadmap.md`

No STOP was needed because the canonical basics exist.

## Estado actual post-PR #25

PR #25 is merged and reconciled provider state across app docs:

- WAQI/AQICN is documented as active provider.
- AirVisual/IQAir is documented as legacy/fallback only.
- Story 1.4 is unlocked as the next Fase 1 gate.

This PR also fixes remaining roadmap drift by marking Story 1.3.1 completed by PR #25.

## Documentos actualizados

- `docs/public-runtime-verification-gate.md`
  - New gate document.
  - Defines public app checks, docs drift checks, pipeline read-only checks, RPC read-only expectations, pass/degraded/fail outcomes, and rollback.

- `docs/roadmap.md`
  - Marks Story 1.3.1 completed by PR #25.
  - Marks Story 1.4 as current/in-progress gate.
  - Adds the new gate document to canonical related docs.

- `docs/DOCUMENTATION_INDEX.md`
  - Adds the new gate document to canonical docs.
  - Updates source-of-truth hierarchy and current gate state.

## Evidencia runtime pública

Checked public URL:

- `https://mtyrespira.elelier.com/`

Result:

- Public app responded.
- Public metadata still includes `Calidad del Aire en Tiempo Real` in the page title.
- This PR does not change runtime copy because the story is docs-only.
- The drift is documented as a follow-up runtime/SEO copy issue.

## Evidencia pipeline read-only

Read-only pipeline evidence reviewed from `elelier/airquality_pipeline`:

- Workflow has hourly cron `0 * * * *`.
- Provider default is `waqi`.
- Manual provider selector allows `waqi` / `airvisual`.
- Read-only RPC health mode exists.

No pipeline files changed.
No productive workflow executed.
No forced live ingestion executed.

## Evidencia contrato RPC o bloqueo

No live Supabase RPC query was executed from this agent session because no Supabase connector/tool was available here.

The gate documents the expected read-only RPC validation checklist for `get_latest_air_quality_per_city` and explicitly blocks SQL/schema/RPC/data changes in this story.

## Impacto por área

- app: docs only; no frontend runtime changes.
- pipeline: read-only reference only; no pipeline changes.
- BD MtyRespira: no writes, no schema changes.
- Supabase RPC: no SQL/RPC changes.
- UX: documents one known public metadata drift; no UI/runtime changes.
- Cloudflare: no deploy/config changes.

## Validación

- Branch diff is docs-only:
  - `docs/public-runtime-verification-gate.md`
  - `docs/roadmap.md`
  - `docs/DOCUMENTATION_INDEX.md`
- Relative doc references reviewed.
- Public app URL checked via safe web fetch.
- Pipeline workflow inspected read-only.
- No `npm run build` was run because no runtime/frontend files changed.

## Riesgos / pendientes

- Public page title still contains `Tiempo Real`; recommended follow-up is a tiny runtime/SEO copy story to soften/remove that claim.
- Supabase RPC evidence still needs manual or agent-enabled read-only verification.
- Because of those two items, Story 1.4 result is documented as degraded pass, not clean pass.

## Siguiente historia recomendada

Recommended next story:

Story 1.4.1 — Public Metadata Freshness Claim Cleanup

Scope should be small:

- Remove or soften public `<title>`/SEO metadata containing `Tiempo Real`.
- Keep UX/runtime behavior unchanged.
- Validate public metadata after deploy.

Alternative if Supabase access becomes available first:

Story 1.4.2 — Read-only RPC Evidence Capture

- Run `get_latest_air_quality_per_city` read-only.
- Capture shape evidence without changing SQL/schema/data.

## Rollback

Revert this documentation PR. Runtime, Supabase, RPC, provider behavior, and Cloudflare config are untouched.