### PR TITLE
fix: remove real-time freshness claim from public metadata

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # MonterreyRespira - Monitor de Calidad del Aire
 
-MonterreyRespira es una aplicación web dedicada a proporcionar información clara, accesible y en tiempo real sobre la calidad del aire en Monterrey y su área metropolitana. Nuestro objetivo es concienciar a la ciudadanía y ofrecer datos útiles para la toma de decisiones diarias.
+MonterreyRespira es una aplicación web dedicada a proporcionar información clara y accesible sobre lecturas disponibles de calidad del aire en Monterrey y su área metropolitana. Nuestro objetivo es concienciar a la ciudadanía y ofrecer datos útiles para la toma de decisiones diarias.
 
 ## 📋 Prerrequisitos
 
@@ -56,7 +56,7 @@ npm run build
 
 ## ✨ Características Clave
 
-*   **Datos en Tiempo Real:** Muestra las últimas lecturas de calidad del aire (AQI US, contaminante principal) y condiciones meteorológicas (temperatura, humedad, viento) para múltiples municipios.
+*   **Lecturas disponibles:** Muestra lecturas de calidad del aire (AQI US, contaminante principal) y condiciones meteorológicas reportadas (temperatura, humedad, viento) para múltiples municipios.
 *   **Fuente de Datos Robusta:** Utiliza un pipeline automatizado que recolecta, procesa y almacena datos de fuentes como AirVisual (IQAir), con planes de integrar otras (ej. SIMA).
 *   **Visualización Geográfica:** (Planeado) Mapa interactivo mostrando la calidad del aire por zona.
 *   **Datos Históricos:** (Planeado) Gráficos y consultas para analizar tendencias pasadas.

--- a/docs/bye/api.md
+++ b/docs/bye/api.md
@@ -1,6 +1,6 @@
 # Documentación de APIs
 
-MonterreyRespira utiliza diversas APIs para obtener datos de calidad del aire en tiempo real. Esta documentación describe las APIs utilizadas, su implementación en el proyecto y las estrategias de fallback.
+MonterreyRespira utiliza APIs para obtener lecturas disponibles de calidad del aire. Esta documentación legacy describe APIs utilizadas históricamente, su implementación anterior y estrategias de fallback.
 
 ## APIs Externas
 

--- a/docs/public-runtime-verification-gate.md
+++ b/docs/public-runtime-verification-gate.md
@@ -78,6 +78,12 @@ This is public metadata/runtime copy, not a documentation claim. It should be tr
 
 Do not fix this in this docs-only gate. Open a separate app runtime/SEO copy story if the team decides to remove that title claim.
 
+### Story 1.4.1 follow-up
+
+Story 1.4.1 — Public Metadata Freshness Claim Cleanup mitigates this metadata drift in source by replacing the public app title and social metadata with `MonterreyRespira - Lecturas de calidad del aire`.
+
+The remaining degraded-pass blocker is Supabase/RPC read-only evidence for `get_latest_air_quality_per_city`; this follow-up does not change data flow, provider behavior, Supabase schema, RPCs, AQI rendering, historical views, or geolocation.
+
 ## 5. Documentation drift verification
 
 Run or document equivalent:
@@ -208,12 +214,12 @@ Use fail when:
 
 ## 9. Current Story 1.4 result
 
-Result: degraded pass.
+Result: degraded pass pending read-only RPC evidence.
 
 Evidence:
 
 - Public app URL responded on 2026-05-22.
-- Public metadata still includes `Calidad del Aire en Tiempo Real`; this is a follow-up runtime/SEO copy drift, not fixed here.
+- Public metadata included `Calidad del Aire en Tiempo Real`; Story 1.4.1 mitigates this runtime/SEO copy drift in source.
 - Pipeline workflow config confirms hourly schedule, default `waqi`, explicit `waqi` / `airvisual` dispatch options, and read-only RPC health mode.
 - No Supabase live query was executed from this agent session because no Supabase connector/tool was available here.
 - No runtime files were changed.
@@ -222,11 +228,10 @@ Evidence:
 
 ## 10. Follow-up recommendations
 
-Recommended next follow-up after this gate:
+Recommended next follow-up after this gate and Story 1.4.1:
 
-1. Small app/SEO copy story to remove or soften public page title metadata containing `Tiempo Real` if confirmed in source.
-2. Manual or agent-enabled read-only Supabase RPC evidence capture for `get_latest_air_quality_per_city`.
-3. Fase 2 Story 2.1 — Docs Drift Cleanup only after the runtime/metadata copy issue is either accepted as known drift or corrected.
+1. Manual or agent-enabled read-only Supabase RPC evidence capture for `get_latest_air_quality_per_city`.
+2. Fase 2 Story 2.1 — Docs Drift Cleanup only after RPC evidence is captured or explicitly accepted as a remaining degraded-pass blocker.
 
 ## 11. Rollback
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -22,7 +22,7 @@ Story 1.3 — Provider Continuity Readiness quedó completada en el repo de pipe
 
 Story 1.3.1 — App Docs Provider State Reconciliation + Roadmap Unlock quedó completada por PR #25 — `docs: reconcile provider state and roadmap after Story 1.3`.
 
-Story 1.4 — Public Runtime Verification Gate queda como gate de verificación documental/QA en curso por esta historia.
+Story 1.4 — Public Runtime Verification Gate queda como gate de verificación documental/QA en curso, con Story 1.4.1 como follow-up mínimo para corregir metadata pública de frescura.
 
 Razón:
 
@@ -154,6 +154,24 @@ Criterio de salida:
 
 - Cada release relevante tiene evidencia mínima de app, pipeline y contrato.
 - Si falta acceso a Supabase/RPC o aparece drift de copy pública, se registra como degraded pass o follow-up explícito.
+
+### Story 1.4.1 — Public Metadata Freshness Claim Cleanup
+
+Estado: en curso por PR pequeño de metadata/copy.
+
+Objetivo: remover claims públicos de `Tiempo Real` en metadata/SEO visible sin cambiar comportamiento de datos.
+
+Alcance:
+
+- Actualizar `<title>`, description y metadata social pública si contienen o heredan claim de frescura excesivo.
+- Mantener intactos AQI card behavior, históricos, geolocalización, Supabase/RPC, provider y pipeline.
+- Actualizar el gate de Story 1.4 para dejar claro que el drift de metadata queda mitigado y que la evidencia RPC read-only sigue pendiente si no se captura.
+
+Criterio de salida:
+
+- La metadata pública de la app no promete `Tiempo Real`.
+- Las apariciones restantes de `tiempo real` quedan limitadas a prohibición, riesgo o drift histórico documentado.
+- Story 1.4 queda lista para Story 1.4.2 — Read-only RPC Evidence Capture si la evidencia RPC sigue pendiente.
 
 ## Fase 2 — Limpieza y gobernanza
 

--- a/index.html
+++ b/index.html
@@ -4,10 +4,10 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="Consulta AQI, contaminante principal y recomendaciones por municipio en la Zona Metropolitana de Monterrey." />
+  <meta name="description" content="Consulta lecturas disponibles de AQI, contaminante principal y recomendaciones por municipio en la Zona Metropolitana de Monterrey." />
   <meta name="theme-color" content="#ffffff">
-  <meta property="og:title" content="MonterreyRespira - Calidad del aire en la Zona Metropolitana" />
-  <meta property="og:description" content="Consulta AQI, contaminante principal y recomendaciones por municipio." />
+  <meta property="og:title" content="MonterreyRespira - Lecturas de calidad del aire" />
+  <meta property="og:description" content="Consulta lecturas disponibles de AQI, contaminante principal y recomendaciones por municipio." />
   <meta property="og:image" content="https://mtyrespira.elelier.com/images/seo/share-image.png" />
   <meta property="og:image:width" content="1200" />
   <meta property="og:image:height" content="630" />
@@ -17,7 +17,7 @@
 
   <link rel="icon" type="image/png" href="/favicon.png" />
   <link rel="manifest" href="/manifest.json">
-  <title>MonterreyRespira - Calidad del aire en la Zona Metropolitana</title>
+  <title>MonterreyRespira - Lecturas de calidad del aire</title>
 </head>
 
 <body>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -17,8 +17,8 @@ interface LayoutProps {
 }
 
 const CITY_SHARE_SIGNAL_FAILED_MESSAGE = 'No se pudo registrar señal anónima de compartir ciudad:';
-const SOCIAL_PREVIEW_TITLE = 'MonterreyRespira - Calidad del aire en la Zona Metropolitana';
-const SOCIAL_PREVIEW_DESCRIPTION = 'Consulta AQI, contaminante principal y recomendaciones por municipio.';
+const SOCIAL_PREVIEW_TITLE = 'MonterreyRespira - Lecturas de calidad del aire';
+const SOCIAL_PREVIEW_DESCRIPTION = 'Consulta lecturas disponibles de AQI, contaminante principal y recomendaciones por municipio.';
 
 const hasShareableAqi = (aqi: number | null | undefined, status: AirQualityStatus): aqi is number => {
   return status !== 'unknown' && hasReliableAqi(aqi);


### PR DESCRIPTION
## Summary
- Replaces public app metadata/title and social preview copy with freshness-honest wording: `MonterreyRespira - Lecturas de calidad del aire`.
- Removes remaining docs/legacy `tiempo real` product-promise wording found by the required grep.
- Updates Story 1.4 gate and roadmap to record Story 1.4.1 as the metadata cleanup follow-up while keeping RPC read-only evidence pending.

## Challenge / básicos canónicos verificados
Verified present before runtime changes:
- `AGENTS.md`
- `docs/PRD.md`
- `docs/architecture.md`
- `docs/roadmap.md`

Also read/reviewed:
- `README.md`
- `docs/DOCUMENTATION_INDEX.md`
- `docs/shared-data-contract.md`
- `docs/freshness-truth-ux.md`
- `docs/blindaje-y-cambio-de-curso.md`
- `docs/public-runtime-verification-gate.md`

## Hallazgo origen
- Story 1.4 documented production metadata drift: public `<title>` returned `MonterreyRespira - Calidad del Aire en Tiempo Real`.
- Runtime source now sets clean static and Helmet metadata; this PR changes it to a clearer follow-up title and description to force an aligned deploy artifact.

## Cambios realizados
- `index.html`: updated `<title>`, `description`, `og:title`, and `og:description`.
- `src/components/Layout.tsx`: updated Helmet/social preview title and description, including Twitter metadata through the shared component.
- `docs/README.md` and `docs/bye/api.md`: removed active `tiempo real` product-promise wording reported by required grep.
- `docs/public-runtime-verification-gate.md`: marks metadata drift mitigated by Story 1.4.1 and keeps RPC evidence as the remaining degraded-pass blocker.
- `docs/roadmap.md`: adds Story 1.4.1 as a small follow-up under Story 1.4.

## Impacto por área
- app: Metadata/copy only. No AQI card behavior, routing logic, historical logic, geolocation, cache, or data queries changed.
- pipeline: No change.
- BD MtyRespira: No change.
- Supabase RPC: No change to `get_latest_air_quality_per_city` or any RPC.
- UX: Public freshness claim softened from real-time language to available readings; visible product behavior unchanged.
- Cloudflare: Next Pages deploy should publish the corrected metadata. No Cloudflare config changed.

## Contract impact
No data contract impact.

No changes to:
- `pipeline -> Supabase/RPC -> frontend -> UX` data flow
- provider runtime
- Supabase schema/table/RPC behavior
- service-role or secrets

## Validation
- `rg "tiempo real|Tiempo Real|real-time|Real Time|Calidad del Aire en Tiempo Real" .`
  - Remaining occurrences are prohibitions, risk/drift history, or Story 1.4.1 references.
- `npm run lint`
  - Passed with existing warnings; no errors.
- `npm run build`
  - Passed.
- `npm run typecheck`
  - Passed.
- Playwright local QA on `http://127.0.0.1:5173/`
  - Page title: `MonterreyRespira - Lecturas de calidad del aire`.
  - Description/OG/Twitter metadata use `lecturas disponibles` wording.
  - No old `Calidad del Aire en Tiempo Real` title in rendered HTML.
  - Main page loaded; `/datos-y-apis` routing loaded.
  - Browser console had no app errors during checks; one pre-existing manifest icon size warning was observed.

## Risks / pending items
- Supabase/RPC live read-only evidence remains pending; no Supabase connector/tool was used and no live query was executed.
- Cloudflare preview URL was not available before PR creation; preview title should be checked after Pages generates it.
- Existing lint warnings remain outside this PR scope.

## Siguiente historia recomendada
Story 1.4.2 — Read-only RPC Evidence Capture, unless an operator has already captured and attached read-only RPC evidence manually.

## Rollback
- Revert this PR.
- No data rollback needed because no Supabase, RPC, provider, or pipeline state changed.