### PR TITLE
docs: record blocked RPC read-only evidence capture

### DIFF
--- a/docs/DOCUMENTATION_INDEX.md
+++ b/docs/DOCUMENTATION_INDEX.md
@@ -1,7 +1,7 @@
 # Documentation Index — MtyRespira
 
 Status: canonical documentation map  
-Date: 2026-05-21
+Date: 2026-05-22
 
 ## Purpose
 
@@ -21,6 +21,7 @@ MtyRespira must remain scoped to the public air-quality product for Monterrey. D
 | `docs/freshness-truth-ux.md` | Freshness UX semantics | Canonical copy/threshold rules for measurement freshness. |
 | `docs/blindaje-y-cambio-de-curso.md` | Risk posture | Premortem-derived guardrails and change-of-course map. |
 | `docs/public-runtime-verification-gate.md` | Runtime verification gate | Minimum safe QA/docs gate for public app, pipeline evidence, and RPC verification after relevant changes. |
+| `docs/evidence/story-1-4-2-rpc-read-only-evidence.md` | RPC evidence/blocker record | Tracks Story 1.4.2 read-only RPC evidence attempt and remaining live Supabase blocker. |
 | `README.md` | Public contributor orientation | Must stay honest, but is not the deepest source of truth. |
 
 ## Cross-repo operational references
@@ -40,6 +41,7 @@ These docs live in `elelier/airquality_pipeline` and are operational references,
 - Roadmap stays at `docs/roadmap.md`.
 - PRD lives at `docs/PRD.md`.
 - Agent rules live at root `AGENTS.md`.
+- Story-specific operational evidence lives under `docs/evidence/` when it is useful for future QA gates.
 
 Do not create duplicate uppercase/lowercase variants unless a future migration deliberately redirects old paths.
 
@@ -55,15 +57,16 @@ When files disagree:
 6. `docs/freshness-truth-ux.md`.
 7. `docs/blindaje-y-cambio-de-curso.md`.
 8. `docs/public-runtime-verification-gate.md` for post-change runtime evidence.
-9. README.
-10. Pipeline provider continuity docs for incident/runbook detail.
+9. Story evidence under `docs/evidence/` for scoped QA outcomes and blockers.
+10. README.
+11. Pipeline provider continuity docs for incident/runbook detail.
 
 ## Drift cleanup rules
 
 Any mention of these terms must be reviewed before merge:
 
 ```bash
-rg "tiempo real|AirVisual|IQAir|WAQI|AQICN|Buildship|Netlify|service_role|Core DB" README.md docs AGENTS.md
+rg "Story 1.4|Story 1.4.1|Story 1.4.2|get_latest_air_quality_per_city|tiempo real|Tiempo Real|AirVisual|IQAir|WAQI|AQICN|service_role|Core DB" README.md docs AGENTS.md
 ```
 
 Allowed appearances:
@@ -74,6 +77,7 @@ Allowed appearances:
 - WAQI/AQICN references as active provider when sourced from pipeline evidence.
 - Core DB clarification that it is not used for environmental readings.
 - Runtime verification evidence or known-drift notes in `docs/public-runtime-verification-gate.md`.
+- Story 1.4 / 1.4.1 / 1.4.2 status and evidence records.
 
 Disallowed appearances:
 
@@ -91,4 +95,8 @@ Story 1.3 — Provider Continuity Readiness is completed by PR #14 in `elelier/a
 
 Story 1.3.1 — App Docs Provider State Reconciliation + Roadmap Unlock is completed by PR #25.
 
-Story 1.4 — Public Runtime Verification Gate is the current Fase 1 QA/docs gate.
+Story 1.4 — Public Runtime Verification Gate remains degraded/open until live read-only RPC evidence is captured or the blocker is explicitly accepted.
+
+Story 1.4.1 — Public Metadata Freshness Claim Cleanup is completed by PR #27.
+
+Story 1.4.2 — Read-only RPC Evidence Capture is blocked/degraded in the current session because no Supabase connector/tool was available for live RPC execution.

--- a/docs/evidence/story-1-4-2-rpc-read-only-evidence.md
+++ b/docs/evidence/story-1-4-2-rpc-read-only-evidence.md
@@ -1,0 +1,136 @@
+# Story 1.4.2 — Read-only RPC Evidence Capture
+
+Status: blocked / degraded evidence  
+Date: 2026-05-22  
+Repo: `elelier/monterrey-respira`  
+Reference repo: `elelier/airquality_pipeline`  
+Scope: QA / Docs / PM-PO only
+
+## Objective
+
+Capture safe evidence for the critical Supabase RPC consumed by the public MtyRespira app:
+
+```ts
+supabase.rpc('get_latest_air_quality_per_city')
+```
+
+This story exists to close the remaining Story 1.4 verification gap without changing runtime, frontend behavior, provider behavior, Supabase schema, RPC definitions, grants, RLS, tables, or live environmental data.
+
+## Scope executed
+
+- Verified that the canonical documentation gate exists before proceeding.
+- Reviewed the app-side RPC consumption path as read-only reference.
+- Prepared a safe evidence record for the RPC check.
+- Did not execute data writes.
+- Did not execute DDL.
+- Did not modify SQL, grants, schema, RLS, function body, WAQI stations, provider runtime, frontend runtime, Cloudflare config, or pipeline runtime.
+
+## Canonical docs checked
+
+Minimum canonical docs are present:
+
+- `AGENTS.md`
+- `docs/PRD.md`
+- `docs/architecture.md`
+- `docs/roadmap.md`
+
+Related docs checked for this evidence gate:
+
+- `README.md`
+- `docs/DOCUMENTATION_INDEX.md`
+- `docs/shared-data-contract.md`
+- `docs/freshness-truth-ux.md`
+- `docs/blindaje-y-cambio-de-curso.md`
+- `docs/public-runtime-verification-gate.md`
+
+## Query / RPC intended
+
+Read-only target:
+
+```ts
+supabase.rpc('get_latest_air_quality_per_city')
+```
+
+Expected fields from `docs/shared-data-contract.md`:
+
+- `city_id`
+- `city_name`
+- `api_name`
+- `latitude`
+- `longitude`
+- `reading_timestamp`
+- `aqi_us`
+- `main_pollutant_us`
+- `temperature_c`
+- `humidity_percent`
+- `wind_speed_ms`
+- `wind_direction_deg`
+- `weather_icon`
+- `last_successful_update_at`
+
+## Evidence captured
+
+Result: blocked / degraded evidence.
+
+Reason:
+
+- The active session exposed GitHub and Notion tooling, but no Supabase connector/tool for live RPC execution.
+- No Supabase URL/key/secret was requested, copied, printed, committed, or exposed.
+- No live RPC response was retrieved from Supabase in this session.
+
+Safe evidence available from repo review:
+
+- The frontend consumes `get_latest_air_quality_per_city` through `src/services/apiService.ts`.
+- The app asserts that the RPC response must be an array before returning it to the UI.
+- The shared data contract defines the canonical latest RPC payload shape listed above.
+- The public runtime verification gate already treats missing RPC evidence as degraded/pass blocker rather than success.
+
+## Evidence not captured
+
+Because live Supabase access was not available, this file does not claim:
+
+- row count,
+- sample city values,
+- observed nullability,
+- observed `reading_timestamp`,
+- observed `last_successful_update_at`,
+- current `aqi_us` values,
+- current pollutant values,
+- whether any expected city is currently missing.
+
+Do not infer or invent any environmental values from this document.
+
+## Outcome
+
+Story 1.4.2 should remain open / blocked until an operator or future agent session with Supabase read-only access captures the RPC response safely.
+
+Story 1.4 remains degraded/open because its two relevant threads are now split as follows:
+
+- Story 1.4.1 — public metadata freshness claim cleanup: completed by PR #27.
+- Story 1.4.2 — read-only RPC evidence capture: blocked in this session because live Supabase RPC access was unavailable.
+
+## Required follow-up evidence
+
+A future read-only evidence run should record:
+
+- execution timestamp,
+- tool used,
+- RPC name,
+- number of rows returned,
+- one or more known supported cities if present,
+- field names observed,
+- nullability observed,
+- timestamp fields observed,
+- any `aqi_us = null` rows without correcting them,
+- any missing expected city without inventing cause.
+
+## No-op / rollback
+
+This file is documentation only.
+
+Rollback:
+
+1. Revert the PR that added this evidence file.
+2. Keep runtime unchanged.
+3. Keep Supabase unchanged.
+4. Re-open Story 1.4.2 if the evidence record is removed.

--- a/docs/public-runtime-verification-gate.md
+++ b/docs/public-runtime-verification-gate.md
@@ -66,30 +66,23 @@ Evidence to capture in the PR:
 - Any visible freshness/degradation state.
 - Any public copy or metadata drift found.
 
-### Current Story 1.4 observation
+### Story 1.4.1 result
 
-A safe public fetch of `https://mtyrespira.elelier.com/` on 2026-05-22 returned the page title:
+Story 1.4.1 — Public Metadata Freshness Claim Cleanup mitigated the prior metadata drift in source by replacing public app title/social metadata with freshness-honest wording.
 
-```text
-MonterreyRespira - Calidad del Aire en Tiempo Real
-```
+Merged evidence:
 
-This is public metadata/runtime copy, not a documentation claim. It should be treated as follow-up drift because the canonical docs prohibit using `tiempo real` as a product promise unless runtime can support that meaning.
+- PR #27 — `fix: remove real-time freshness claim from public metadata`.
+- Corrected title/copy target: `MonterreyRespira - Lecturas de calidad del aire`.
 
-Do not fix this in this docs-only gate. Open a separate app runtime/SEO copy story if the team decides to remove that title claim.
-
-### Story 1.4.1 follow-up
-
-Story 1.4.1 — Public Metadata Freshness Claim Cleanup mitigates this metadata drift in source by replacing the public app title and social metadata with `MonterreyRespira - Lecturas de calidad del aire`.
-
-The remaining degraded-pass blocker is Supabase/RPC read-only evidence for `get_latest_air_quality_per_city`; this follow-up does not change data flow, provider behavior, Supabase schema, RPCs, AQI rendering, historical views, or geolocation.
+This follow-up did not change data flow, provider behavior, Supabase schema, RPCs, AQI rendering, historical views, or geolocation.
 
 ## 5. Documentation drift verification
 
 Run or document equivalent:
 
 ```bash
-rg "tiempo real|AirVisual|IQAir|WAQI|AQICN|Buildship|Netlify|privileged database key|Core DB" README.md docs AGENTS.md
+rg "Story 1.4|Story 1.4.1|Story 1.4.2|get_latest_air_quality_per_city|tiempo real|Tiempo Real|AirVisual|IQAir|WAQI|AQICN|service_role|Core DB" README.md docs AGENTS.md
 ```
 
 Allowed appearances:
@@ -99,7 +92,7 @@ Allowed appearances:
 - AirVisual/IQAir only as legacy/fallback, not active provider.
 - Privileged database key wording only as security prohibition or pipeline-only secret context.
 - Core DB only as a clarification that it is not used for environmental readings.
-- Buildship/Netlify only as legacy context, not active runtime.
+- Story 1.4 / 1.4.1 / 1.4.2 evidence and status references.
 
 Disallowed appearances:
 
@@ -164,13 +157,13 @@ Preferred read-only evidence:
 - `last_successful_update_at` remains pipeline traceability.
 - Nullable fields remain treated as nullable.
 
-If Supabase is not connected to the agent, do not guess. Record the blocker and ask an operator to run a read-only sample of `get_latest_air_quality_per_city` in Supabase.
-
-Manual reviewer should verify:
+Expected fields:
 
 - `city_id`
 - `city_name`
 - `api_name`
+- `latitude`
+- `longitude`
 - `reading_timestamp`
 - `aqi_us`
 - `main_pollutant_us`
@@ -181,7 +174,29 @@ Manual reviewer should verify:
 - `weather_icon`
 - `last_successful_update_at`
 
+If Supabase is not connected to the agent, do not guess. Record the blocker and ask an operator to run a read-only sample of `get_latest_air_quality_per_city` in Supabase.
+
 Do not change SQL, grants, schema, function body, RLS, or data as part of this gate.
+
+### Story 1.4.2 attempt
+
+Story 1.4.2 attempted to capture read-only RPC evidence in a GitHub/Notion agent session.
+
+Result: blocked / degraded evidence.
+
+Evidence file:
+
+- `docs/evidence/story-1-4-2-rpc-read-only-evidence.md`
+
+Reason:
+
+- GitHub and Notion tooling were available.
+- No Supabase connector/tool was available for live RPC execution.
+- No Supabase URL/key/secret was requested, printed, copied, committed, or exposed.
+- No live RPC response was retrieved.
+- No writes, DDL, SQL/RPC/schema/grants/RLS changes, frontend runtime changes, pipeline changes, provider changes, or Cloudflare changes were performed.
+
+Story 1.4.2 remains blocked until a future operator or agent session with read-only Supabase access records live RPC row count, fields, nullability, timestamps, and sampled city presence.
 
 ## 8. Pass / degraded / fail outcomes
 
@@ -214,24 +229,25 @@ Use fail when:
 
 ## 9. Current Story 1.4 result
 
-Result: degraded pass pending read-only RPC evidence.
+Result: degraded/open pending live read-only RPC evidence.
 
 Evidence:
 
-- Public app URL responded on 2026-05-22.
-- Public metadata included `Calidad del Aire en Tiempo Real`; Story 1.4.1 mitigates this runtime/SEO copy drift in source.
-- Pipeline workflow config confirms hourly schedule, default `waqi`, explicit `waqi` / `airvisual` dispatch options, and read-only RPC health mode.
-- No Supabase live query was executed from this agent session because no Supabase connector/tool was available here.
-- No runtime files were changed.
-- No pipeline files were changed.
+- Story 1.4.1 / PR #27 mitigated public metadata freshness-claim drift in source.
+- Pipeline workflow config previously confirmed hourly schedule, default `waqi`, explicit `waqi` / `airvisual` dispatch options, and read-only RPC health mode.
+- Story 1.4.2 created a safe evidence/blocker file for RPC capture.
+- No Supabase live query was executed in Story 1.4.2 because no Supabase connector/tool was available in that session.
+- No runtime files were changed by Story 1.4.2.
+- No pipeline files were changed by Story 1.4.2.
 - No Supabase writes were performed.
 
 ## 10. Follow-up recommendations
 
-Recommended next follow-up after this gate and Story 1.4.1:
+Recommended next follow-up:
 
-1. Manual or agent-enabled read-only Supabase RPC evidence capture for `get_latest_air_quality_per_city`.
-2. Fase 2 Story 2.1 — Docs Drift Cleanup only after RPC evidence is captured or explicitly accepted as a remaining degraded-pass blocker.
+1. Run `get_latest_air_quality_per_city` with read-only Supabase access and update `docs/evidence/story-1-4-2-rpc-read-only-evidence.md` with real observed evidence.
+2. Only after that, mark Story 1.4 completed or explicitly accept the remaining degraded blocker.
+3. Do not start Fase 2 as the main track until Story 1.4 is closed or the blocker is explicitly accepted.
 
 ## 11. Rollback
 
@@ -239,6 +255,6 @@ This file is documentation only.
 
 Rollback:
 
-1. Revert the PR that added this file.
+1. Revert the PR that updated this file.
 2. Keep runtime unchanged.
-3. Re-open Story 1.4 if the removed evidence still needs to be captured.
+3. Re-open Story 1.4 / Story 1.4.2 if the removed evidence status still needs to be tracked.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,7 +1,7 @@
 # Roadmap — MtyRespira
 
 Estado: brownfield operativo  
-Fecha: 2026-05-21
+Fecha: 2026-05-22
 
 ## Cambio de curso
 
@@ -22,15 +22,20 @@ Story 1.3 — Provider Continuity Readiness quedó completada en el repo de pipe
 
 Story 1.3.1 — App Docs Provider State Reconciliation + Roadmap Unlock quedó completada por PR #25 — `docs: reconcile provider state and roadmap after Story 1.3`.
 
-Story 1.4 — Public Runtime Verification Gate queda como gate de verificación documental/QA en curso, con Story 1.4.1 como follow-up mínimo para corregir metadata pública de frescura.
+Story 1.4 — Public Runtime Verification Gate sigue en estado degraded/open porque la evidencia live read-only de la RPC `get_latest_air_quality_per_city` no pudo capturarse en la sesión de Story 1.4.2 por falta de herramienta Supabase disponible.
+
+Story 1.4.1 — Public Metadata Freshness Claim Cleanup quedó completada por PR #27 — `fix: remove real-time freshness claim from public metadata`.
+
+Story 1.4.2 — Read-only RPC Evidence Capture queda bloqueada/degraded en esta sesión. Existe evidencia documental del bloqueo en `docs/evidence/story-1-4-2-rpc-read-only-evidence.md`, pero no existe todavía evidencia live de filas, shape observado o nullability observada contra Supabase.
 
 Razón:
 
-- El repo app ya cuenta con `AGENTS.md` raíz.
-- El repo app ya cuenta con PRD, arquitectura, roadmap e índice documental canónicos.
-- README ya no promete “tiempo real”.
-- El pipeline ya documentó WAQI/AQICN como proveedor activo y AirVisual/IQAir como legacy/fallback explícito.
-- La siguiente necesidad crítica es verificar runtime público, workflow horario y contrato después de cambios relevantes.
+- El repo app cuenta con `AGENTS.md` raíz.
+- El repo app cuenta con PRD, arquitectura, roadmap e índice documental canónicos.
+- README ya no promete `tiempo real`.
+- La metadata pública fue corregida por Story 1.4.1 / PR #27.
+- El pipeline documenta WAQI/AQICN como proveedor activo y AirVisual/IQAir como legacy/fallback explícito.
+- Falta capturar evidencia live read-only contra `get_latest_air_quality_per_city` con herramienta Supabase disponible.
 
 ## Fase 1 — Blindaje crítico
 
@@ -39,14 +44,6 @@ Razón:
 Estado: completada si existe PR merged con evidencia de smoke/nullability.
 
 Objetivo: crear evidencia repetible de lo que devuelve `get_latest_air_quality_per_city`.
-
-Alcance:
-
-- Validar columnas esperadas.
-- Validar nullability observada.
-- Validar timestamps UTC.
-- Validar una o más ciudades conocidas.
-- Dejar fixture o smoke test canónico.
 
 Criterio de salida:
 
@@ -59,12 +56,6 @@ Estado: completada por PR #23 — `feat: add freshness truth UX guard`.
 
 Objetivo: evitar que la app comunique datos viejos como si fueran frescos.
 
-Alcance:
-
-- Distinguir medición, actualización de pipeline y refresh de frontend.
-- Mostrar estado fresco, viejo, degradado o faltante.
-- Evitar lenguaje de “tiempo real” cuando exceda la cadencia real del productor.
-
 Criterio de salida:
 
 - La UI no sobrepromete frescura.
@@ -76,22 +67,13 @@ Estado: completada por PR #24 — `docs: add canonical MtyRespira project docs b
 
 Objetivo: crear o normalizar los documentos mínimos que gobiernan el proyecto antes de seguir con historias de implementación.
 
-Alcance completado:
-
-- Crear `AGENTS.md` en raíz.
-- Crear `docs/PRD.md` como PRD canónico.
-- Confirmar `docs/architecture.md` como arquitectura canónica sin duplicar `docs/ARCHITECTURE.md`.
-- Confirmar `docs/roadmap.md` como roadmap canónico sin duplicar `docs/ROADMAP.md`.
-- Limpiar README para no prometer “tiempo real”.
-- Crear `docs/DOCUMENTATION_INDEX.md` como índice/fuente de verdad.
-
 Criterio de salida:
 
 - Existe `AGENTS.md` en raíz.
 - Existe PRD canónico.
 - Existe architecture canónica.
 - Existe roadmap canónico.
-- README ya no promete “tiempo real”.
+- README ya no promete `tiempo real`.
 - No hubo cambios runtime, Supabase, RPC ni pipeline en el repo app.
 
 ### Story 1.3 — Provider Continuity Readiness
@@ -99,17 +81,6 @@ Criterio de salida:
 Estado: completada por PR #14 en `elelier/airquality_pipeline` — `docs: add provider continuity readiness runbook`.
 
 Objetivo: preparar fallas del proveedor activo sin romper la experiencia pública.
-
-Alcance completado:
-
-- Verificar proveedor activo contra `airquality_pipeline`, no contra memoria o README legacy.
-- Documentar WAQI/AQICN como provider activo.
-- Documentar AirVisual/IQAir como provider legacy/fallback, no activo.
-- Confirmar `AIR_QUALITY_PROVIDER=waqi` como default.
-- Confirmar `workflow_dispatch` con opciones `waqi` / `airvisual`.
-- Documentar taxonomía de errores upstream.
-- Documentar runbook de contingencia.
-- Evitar fallback productivo no verificado.
 
 Criterio de salida:
 
@@ -122,13 +93,6 @@ Estado: completada por PR #25 — `docs: reconcile provider state and roadmap af
 
 Objetivo: reconciliar los documentos canónicos del repo app con el estado real post-PR #14 del pipeline.
 
-Alcance completado:
-
-- Desbloquear roadmap post Story 1.3.
-- Alinear arquitectura a WAQI/AQICN como provider activo.
-- Alinear contrato compartido a provider genérico con WAQI/AQICN activo y AirVisual/IQAir legacy/fallback.
-- Alinear PRD e índice documental con el estado post-PR #14.
-
 Criterio de salida:
 
 - ROADMAP no deja Story 1.2.1 como en curso.
@@ -139,7 +103,7 @@ Criterio de salida:
 
 ### Story 1.4 — Public Runtime Verification Gate
 
-Estado: en curso por esta historia.
+Estado: degraded/open.
 
 Objetivo: verificar producción después de cambios relevantes.
 
@@ -153,27 +117,45 @@ Alcance:
 Criterio de salida:
 
 - Cada release relevante tiene evidencia mínima de app, pipeline y contrato.
-- Si falta acceso a Supabase/RPC o aparece drift de copy pública, se registra como degraded pass o follow-up explícito.
+- La evidencia RPC live read-only confirma shape/nullability esperada, o queda bloqueo explícito.
+
+Bloqueo actual:
+
+- No se pudo ejecutar Supabase RPC desde la sesión de Story 1.4.2 porque solo hubo tooling GitHub/Notion disponible.
+- No se debe marcar Story 1.4 como completada hasta capturar evidencia live read-only de `get_latest_air_quality_per_city`.
 
 ### Story 1.4.1 — Public Metadata Freshness Claim Cleanup
 
-Estado: en curso por PR pequeño de metadata/copy.
+Estado: completada por PR #27 — `fix: remove real-time freshness claim from public metadata`.
 
 Objetivo: remover claims públicos de `Tiempo Real` en metadata/SEO visible sin cambiar comportamiento de datos.
-
-Alcance:
-
-- Actualizar `<title>`, description y metadata social pública si contienen o heredan claim de frescura excesivo.
-- Mantener intactos AQI card behavior, históricos, geolocalización, Supabase/RPC, provider y pipeline.
-- Actualizar el gate de Story 1.4 para dejar claro que el drift de metadata queda mitigado y que la evidencia RPC read-only sigue pendiente si no se captura.
 
 Criterio de salida:
 
 - La metadata pública de la app no promete `Tiempo Real`.
 - Las apariciones restantes de `tiempo real` quedan limitadas a prohibición, riesgo o drift histórico documentado.
-- Story 1.4 queda lista para Story 1.4.2 — Read-only RPC Evidence Capture si la evidencia RPC sigue pendiente.
+- Story 1.4 queda lista para Story 1.4.2 si la evidencia RPC sigue pendiente.
+
+### Story 1.4.2 — Read-only RPC Evidence Capture
+
+Estado: bloqueada/degraded en esta sesión.
+
+Objetivo: capturar evidencia read-only de la RPC crítica `get_latest_air_quality_per_city` sin modificar datos, SQL, provider, pipeline, frontend ni Cloudflare.
+
+Resultado de esta sesión:
+
+- Se creó `docs/evidence/story-1-4-2-rpc-read-only-evidence.md`.
+- No se capturó respuesta live de Supabase porque no hubo herramienta Supabase disponible.
+- No hubo writes, DDL, cambios SQL/RPC/schema/grants/RLS, cambios frontend, cambios pipeline ni cambios provider.
+
+Criterio de salida pendiente:
+
+- Capturar timestamp de ejecución, herramienta usada, filas devueltas, ciudades observadas, shape de campos, nullability observada y timestamps presentes.
+- Documentar cualquier `aqi_us` nulo o ciudad faltante sin corregirlo ni inventar causa.
 
 ## Fase 2 — Limpieza y gobernanza
+
+No iniciar Fase 2 como trabajo principal hasta cerrar o aceptar explícitamente el bloqueo de Story 1.4 / Story 1.4.2.
 
 ### Story 2.1 — Docs Drift Cleanup
 
@@ -226,5 +208,6 @@ Solo después de cerrar Fase 1:
 - `docs/freshness-truth-ux.md`
 - `docs/blindaje-y-cambio-de-curso.md`
 - `docs/public-runtime-verification-gate.md`
+- `docs/evidence/story-1-4-2-rpc-read-only-evidence.md`
 - `elelier/airquality_pipeline/docs/provider-continuity-readiness.md`
 - `elelier/airquality_pipeline/docs/provider-continuity-runbook.md`


### PR DESCRIPTION
## Summary
- Adds `docs/evidence/story-1-4-2-rpc-read-only-evidence.md` as the safe evidence record for Story 1.4.2.
- Documents that live RPC evidence could not be captured because this session had GitHub/Notion tooling but no Supabase connector/tool.
- Reconciles `docs/public-runtime-verification-gate.md`, `docs/roadmap.md`, and `docs/DOCUMENTATION_INDEX.md` so Story 1.4.1 is no longer in progress and Story 1.4 / 1.4.2 remain degraded/open until live read-only RPC evidence is captured.

## Challenge / básicos canónicos verificados
Verified present before continuing:
- `AGENTS.md`
- `docs/PRD.md`
- `docs/architecture.md`
- `docs/roadmap.md`

Also reviewed / used as references:
- `README.md`
- `docs/DOCUMENTATION_INDEX.md`
- `docs/shared-data-contract.md`
- `docs/freshness-truth-ux.md`
- `docs/blindaje-y-cambio-de-curso.md`
- `docs/public-runtime-verification-gate.md`
- `src/services/apiService.ts`
- PR #27 metadata cleanup result

## Area touched
- app: docs only.
- pipeline: no change; reference only.
- BD MtyRespira: no change.
- Supabase RPC: no change.
- Core DB: no change.
- Cloudflare: no change.
- UX: documentation/status only.

## Contract impact
No data contract change.

No changes to:
- `get_latest_air_quality_per_city`
- Supabase schema/tables/RPC/grants/RLS
- provider runtime
- WAQI station mappings
- frontend runtime
- AQI rendering
- historical readings
- geolocation
- Cloudflare config

## Validation
- Compared branch vs `main`: docs-only changes in 4 files.
- Confirmed Story 1.4.1 is now documented as completed by PR #27.
- Confirmed Story 1.4 / Story 1.4.2 are not falsely marked completed.
- Confirmed the new evidence file does not invent row counts, AQI values, city samples, nullability, timestamps, or causes.
- No Supabase writes were performed.
- No DDL was performed.
- No live RPC execution was claimed.

## Risks / pending items
- Story 1.4.2 remains blocked until an operator or future session with Supabase read-only access captures live evidence from `get_latest_air_quality_per_city`.
- Story 1.4 remains degraded/open and should not unlock Fase 2 as main track unless this blocker is explicitly accepted.

## Rollback
- Revert this PR.
- No data rollback required because this PR is documentation only.