### PR TITLE
fix: consume canonical weather history fields

### DIFF
--- a/src/components/CityHistoricalTrend.tsx
+++ b/src/components/CityHistoricalTrend.tsx
@@ -232,12 +232,12 @@ export default function CityHistoricalTrend({ cityId, cityName }: CityHistorical
           {loading ? 'Cargando historico disponible...' : getInsufficientDataCopy(metric)}
         </div>
       ) : (
-        <div className="h-24 w-full sm:h-56" style={{ color: theme.secondary }} aria-label={`Grafica historica de ${metricConfig.label} para ${cityName}`}>
+        <div className="h-28 w-full sm:h-56" style={{ color: theme.secondary }} aria-label={`Grafica historica de ${metricConfig.label} para ${cityName}`}>
           <ResponsiveContainer width="100%" height="100%">
-            <LineChart data={chartPoints} margin={{ top: 4, right: 6, left: -20, bottom: -4 }}>
+            <LineChart data={chartPoints} margin={{ top: 8, right: 10, left: 8, bottom: 0 }}>
               <CartesianGrid strokeDasharray="3 3" vertical={false} />
-              <XAxis dataKey="label" tick={{ fontSize: 10 }} minTickGap={24} />
-              <YAxis tick={{ fontSize: 10 }} width={36} domain={['auto', 'auto']} />
+              <XAxis dataKey="label" tick={{ fontSize: 10 }} minTickGap={24} tickMargin={8} />
+              <YAxis tick={{ fontSize: 10 }} width={42} domain={['auto', 'auto']} tickMargin={6} />
               <Tooltip labelFormatter={(_, payload) => {
                 const point = payload?.[0]?.payload as ChartPoint | undefined;
                 return point ? formatNullableTimestamp(point.timestamp, { dateStyle: 'medium', timeStyle: range === '6m' ? undefined : 'short' }) : 'Medicion';

--- a/src/components/CityHistoricalTrend.tsx
+++ b/src/components/CityHistoricalTrend.tsx
@@ -1,25 +1,8 @@
 import { useEffect, useMemo, useState } from 'react';
-import {
-  Bar,
-  BarChart,
-  CartesianGrid,
-  Line,
-  LineChart,
-  ResponsiveContainer,
-  Tooltip,
-  XAxis,
-  YAxis,
-} from 'recharts';
+import { Bar, BarChart, CartesianGrid, Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
 import { IoTrendingUpOutline } from 'react-icons/io5';
-import {
-  AirQualityDailyHistoryRow,
-  AirQualityHistoryRow,
-  AirQualityTrend,
-} from '../types';
-import {
-  fetchAirQualityHistoryForCity,
-  fetchDailyAirQualityHistoryForCity,
-} from '../services/apiService';
+import { AirQualityDailyHistoryRow, AirQualityHistoryMetric, AirQualityHistoryRow, AirQualityTrend } from '../types';
+import { fetchAirQualityHistoryForCity, fetchDailyAirQualityHistoryForCity } from '../services/apiService';
 import { useAirQuality } from '../context/AirQualityContext';
 import { AQI_THEME_TOKENS } from '../utils/aqiDesignTokens';
 import { formatNullableTimestamp, isFiniteNumber } from '../utils/airQualityDisplay';
@@ -30,7 +13,6 @@ interface CityHistoricalTrendProps {
 }
 
 type HistoryRange = '24h' | '7d' | '30d' | '6m';
-type HistoryMetric = 'aqi_us' | 'temperature_c' | 'humidity_percent';
 type HistoryRow = AirQualityHistoryRow | AirQualityDailyHistoryRow;
 
 interface ChartPoint {
@@ -52,10 +34,11 @@ const RANGE_OPTIONS: { label: string; value: HistoryRange }[] = [
   { label: '6m', value: '6m' },
 ];
 
-const METRIC_OPTIONS: { label: string; value: HistoryMetric; suffix: string }[] = [
+const METRIC_OPTIONS: { label: string; value: AirQualityHistoryMetric; suffix: string }[] = [
   { label: 'AQI', value: 'aqi_us', suffix: ' AQI' },
-  { label: 'Temperatura', value: 'temperature_c', suffix: ' °C' },
-  { label: 'Humedad', value: 'humidity_percent', suffix: '%' },
+  { label: 'Temp.', value: 'weather_temperature_c', suffix: ' C' },
+  { label: 'Humedad', value: 'weather_humidity_percent', suffix: '%' },
+  { label: 'Viento', value: 'weather_wind_speed_kmh', suffix: ' km/h' },
 ];
 
 const RANGE_TO_HOURS: Record<Exclude<HistoryRange, '6m'>, number> = {
@@ -66,62 +49,52 @@ const RANGE_TO_HOURS: Record<Exclude<HistoryRange, '6m'>, number> = {
 
 const SIX_MONTH_DAYS = 183;
 const MIN_POINTS_FOR_TREND = 2;
-const STABLE_DELTA_BY_METRIC: Record<HistoryMetric, number> = {
+const STABLE_DELTA_BY_METRIC: Record<AirQualityHistoryMetric, number> = {
   aqi_us: 5,
-  temperature_c: 1,
-  humidity_percent: 3,
+  weather_temperature_c: 1,
+  weather_humidity_percent: 3,
+  weather_wind_speed_kmh: 5,
 };
 
 function isDailyRow(row: HistoryRow): row is AirQualityDailyHistoryRow {
   return 'reading_date' in row;
 }
 
-function getMetricConfig(metric: HistoryMetric) {
-  const config = METRIC_OPTIONS.find((option) => option.value === metric);
-  return config ?? METRIC_OPTIONS[0];
+function isWeatherMetric(metric: AirQualityHistoryMetric) {
+  return metric !== 'aqi_us';
 }
 
-function getTimestamp(row: HistoryRow) {
-  return isDailyRow(row) ? row.reading_date : row.reading_timestamp;
+function getMetricConfig(metric: AirQualityHistoryMetric) {
+  return METRIC_OPTIONS.find((option) => option.value === metric) ?? METRIC_OPTIONS[0];
+}
+
+function getTimestamp(row: HistoryRow, metric: AirQualityHistoryMetric) {
+  if (isDailyRow(row)) return row.reading_date;
+  return isWeatherMetric(metric) ? (row.weather_timestamp ?? row.reading_timestamp) : row.reading_timestamp;
 }
 
 function getPollutant(row: HistoryRow) {
   return isDailyRow(row) ? row.dominant_pollutant_us : row.main_pollutant_us;
 }
 
-function getMetricValue(row: HistoryRow, metric: HistoryMetric): number | null {
+function getMetricValue(row: HistoryRow, metric: AirQualityHistoryMetric): number | null {
   if (isDailyRow(row)) {
-    switch (metric) {
-      case 'temperature_c':
-        return row.avg_temperature_c;
-      case 'humidity_percent':
-        return row.avg_humidity_percent;
-      default:
-        return row.avg_aqi_us;
-    }
+    if (metric === 'weather_temperature_c') return row.avg_weather_temperature_c;
+    if (metric === 'weather_humidity_percent') return row.avg_weather_humidity_percent;
+    if (metric === 'weather_wind_speed_kmh') return row.avg_weather_wind_speed_kmh;
+    return row.avg_aqi_us;
   }
 
-  switch (metric) {
-    case 'temperature_c':
-      return row.temperature_c;
-    case 'humidity_percent':
-      return row.humidity_percent;
-    default:
-      return row.aqi_us;
-  }
+  if (metric === 'weather_temperature_c') return row.weather_temperature_c;
+  if (metric === 'weather_humidity_percent') return row.weather_humidity_percent;
+  if (metric === 'weather_wind_speed_kmh') return row.weather_wind_speed_kmh;
+  return row.aqi_us;
 }
 
 function formatPointLabel(timestamp: string, range: HistoryRange) {
   const date = new Date(timestamp);
-
-  if (Number.isNaN(date.getTime())) {
-    return 'N/D';
-  }
-
-  if (range === '6m') {
-    return date.toLocaleDateString('es-MX', { month: 'short', day: '2-digit' });
-  }
-
+  if (Number.isNaN(date.getTime())) return 'N/D';
+  if (range === '6m') return date.toLocaleDateString('es-MX', { month: 'short', day: '2-digit' });
   return date.toLocaleString('es-MX', {
     day: range === '24h' ? undefined : '2-digit',
     month: range === '24h' ? undefined : 'short',
@@ -130,136 +103,83 @@ function formatPointLabel(timestamp: string, range: HistoryRange) {
   });
 }
 
-function toChartPoint(
-  row: HistoryRow,
-  range: HistoryRange,
-  metric: HistoryMetric,
-): ChartPoint | null {
+function toChartPoint(row: HistoryRow, range: HistoryRange, metric: AirQualityHistoryMetric): ChartPoint | null {
   const metricValue = getMetricValue(row, metric);
-
-  if (!isFiniteNumber(metricValue)) {
-    return null;
-  }
-
-  const timestamp = getTimestamp(row);
-
-  return {
-    timestamp,
-    label: formatPointLabel(timestamp, range),
-    value: Number(metricValue.toFixed(1)),
-  };
+  if (!isFiniteNumber(metricValue)) return null;
+  const timestamp = getTimestamp(row, metric);
+  return { timestamp, label: formatPointLabel(timestamp, range), value: Number(metricValue.toFixed(1)) };
 }
 
-function calculateTrend(points: ChartPoint[], metric: HistoryMetric): AirQualityTrend {
-  if (points.length < MIN_POINTS_FOR_TREND) {
-    return 'insufficient-data';
-  }
-
+function calculateTrend(points: ChartPoint[], metric: AirQualityHistoryMetric): AirQualityTrend {
+  if (points.length < MIN_POINTS_FOR_TREND) return 'insufficient-data';
   const firstPoint = points[0];
   const lastPoint = points[points.length - 1];
-
-  if (!firstPoint || !lastPoint) {
-    return 'insufficient-data';
-  }
-
+  if (!firstPoint || !lastPoint) return 'insufficient-data';
   const delta = lastPoint.value - firstPoint.value;
-
-  if (Math.abs(delta) <= STABLE_DELTA_BY_METRIC[metric]) {
-    return 'stable';
-  }
-
+  if (Math.abs(delta) <= STABLE_DELTA_BY_METRIC[metric]) return 'stable';
   return delta > 0 ? 'rising' : 'falling';
 }
 
 function getTrendLabel(trend: AirQualityTrend) {
-  switch (trend) {
-    case 'rising':
-      return 'Subiendo';
-    case 'falling':
-      return 'Bajando';
-    case 'stable':
-      return 'Estable';
-    default:
-      return 'Sin datos suficientes';
-  }
+  if (trend === 'rising') return 'Subiendo';
+  if (trend === 'falling') return 'Bajando';
+  if (trend === 'stable') return 'Estable';
+  return 'Sin datos suficientes';
 }
 
-function getMetricCopy(metric: HistoryMetric, range: HistoryRange) {
-  if (range === '6m') {
-    return metric === 'aqi_us' ? 'promedio diario de AQI' : 'promedio diario';
-  }
+function getMetricCopy(metric: AirQualityHistoryMetric, range: HistoryRange) {
+  if (range === '6m') return metric === 'aqi_us' ? 'promedio diario de AQI' : 'promedio diario de clima';
+  return isWeatherMetric(metric) ? 'campos de clima disponibles' : 'mediciones disponibles';
+}
 
-  return 'mediciones disponibles';
+function getInsufficientDataCopy(metric: AirQualityHistoryMetric) {
+  return isWeatherMetric(metric)
+    ? 'Aun no hay suficientes mediciones de clima para graficar esta metrica.'
+    : 'Aun no hay suficientes mediciones para graficar esta metrica.';
 }
 
 function buildPollutantSummary(rows: HistoryRow[]): PollutantSummaryItem[] {
   const counts = rows.reduce<Map<string, number>>((summary, row) => {
     const pollutant = getPollutant(row);
-
-    if (!pollutant) {
-      return summary;
-    }
-
+    if (!pollutant) return summary;
     summary.set(pollutant, (summary.get(pollutant) ?? 0) + 1);
     return summary;
   }, new Map<string, number>());
-
   const total = Array.from(counts.values()).reduce((sum, count) => sum + count, 0);
-
-  if (total === 0) {
-    return [];
-  }
-
+  if (total === 0) return [];
   return Array.from(counts.entries())
-    .map(([pollutant, count]) => ({
-      pollutant,
-      count,
-      percentage: Math.round((count / total) * 100),
-    }))
+    .map(([pollutant, count]) => ({ pollutant, count, percentage: Math.round((count / total) * 100) }))
     .sort((left, right) => right.count - left.count);
 }
 
 export default function CityHistoricalTrend({ cityId, cityName }: CityHistoricalTrendProps) {
   const { airQualityData } = useAirQuality();
   const [range, setRange] = useState<HistoryRange>('30d');
-  const [metric, setMetric] = useState<HistoryMetric>('aqi_us');
+  const [metric, setMetric] = useState<AirQualityHistoryMetric>('aqi_us');
   const [rows, setRows] = useState<HistoryRow[]>([]);
   const [loading, setLoading] = useState(false);
   const [degradedReason, setDegradedReason] = useState<string | null>(null);
 
   useEffect(() => {
     let isCurrent = true;
-
     async function loadHistory() {
       setLoading(true);
       setDegradedReason(null);
-
       try {
         const historyRows = range === '6m'
           ? await fetchDailyAirQualityHistoryForCity(cityId, SIX_MONTH_DAYS)
           : await fetchAirQualityHistoryForCity(cityId, RANGE_TO_HOURS[range]);
-
-        if (!isCurrent) {
-          return;
-        }
-
-        setRows(historyRows);
+        if (isCurrent) setRows(historyRows);
       } catch {
-        if (!isCurrent) {
-          return;
-        }
-
-        setRows([]);
-        setDegradedReason('Historico no disponible por ahora. El panel principal sigue usando datos recientes.');
-      } finally {
         if (isCurrent) {
-          setLoading(false);
+          setRows([]);
+          setDegradedReason('Historico no disponible por ahora. El panel principal sigue usando datos recientes.');
         }
+      } finally {
+        if (isCurrent) setLoading(false);
       }
     }
-
     loadHistory();
-
     return () => {
       isCurrent = false;
     };
@@ -267,9 +187,7 @@ export default function CityHistoricalTrend({ cityId, cityName }: CityHistorical
 
   const metricConfig = getMetricConfig(metric);
   const chartPoints = useMemo(
-    () => rows
-      .map((row) => toChartPoint(row, range, metric))
-      .filter((point): point is ChartPoint => point !== null),
+    () => rows.map((row) => toChartPoint(row, range, metric)).filter((point): point is ChartPoint => point !== null),
     [metric, range, rows],
   );
   const trend = useMemo(() => calculateTrend(chartPoints, metric), [chartPoints, metric]);
@@ -284,115 +202,60 @@ export default function CityHistoricalTrend({ cityId, cityName }: CityHistorical
       <div className="mb-1.5 flex items-center justify-between gap-3 sm:mb-4">
         <div className="flex min-w-0 items-center gap-2.5 sm:gap-3">
           <IoTrendingUpOutline className="h-5 w-5 shrink-0 sm:h-7 sm:w-7" style={{ color: theme.secondary }} />
-          <h2 className="truncate text-[0.94rem] font-semibold text-slate-950 dark:text-white sm:text-xl sm:font-black">
-            Tendencia reciente
-          </h2>
+          <h2 className="truncate text-[0.94rem] font-semibold text-slate-950 dark:text-white sm:text-xl sm:font-black">Tendencia reciente</h2>
         </div>
-        <span
-          className="hidden w-fit rounded-full border px-3 py-1 text-xs font-semibold sm:inline-flex"
-          style={{ borderColor: `${theme.primary}66`, color: theme.text, backgroundColor: `${theme.primary}18` }}
-        >
+        <span className="hidden w-fit rounded-full border px-3 py-1 text-xs font-semibold sm:inline-flex" style={{ borderColor: `${theme.primary}66`, color: theme.text, backgroundColor: `${theme.primary}18` }}>
           {getTrendLabel(trend)}
         </span>
       </div>
 
       <div className="mb-1.5 grid grid-cols-4 rounded-full border border-slate-200 bg-white p-0.5 dark:border-slate-700 dark:bg-slate-900/60 sm:mb-3 sm:p-1">
         {RANGE_OPTIONS.map((option) => (
-          <button
-            key={option.value}
-            type="button"
-            onClick={() => setRange(option.value)}
-            className="rounded-full px-3 py-0.5 text-xs font-medium transition sm:py-2 sm:text-sm sm:font-black"
-            style={{
-              backgroundColor: range === option.value ? `${theme.primary}22` : 'transparent',
-              color: range === option.value ? theme.text : undefined,
-              boxShadow: range === option.value ? `inset 0 0 0 1px ${theme.primary}66` : undefined,
-            }}
-            aria-pressed={range === option.value}
-          >
+          <button key={option.value} type="button" onClick={() => setRange(option.value)} className="rounded-full px-3 py-0.5 text-xs font-medium transition sm:py-2 sm:text-sm sm:font-black" style={{ backgroundColor: range === option.value ? `${theme.primary}22` : 'transparent', color: range === option.value ? theme.text : undefined, boxShadow: range === option.value ? `inset 0 0 0 1px ${theme.primary}66` : undefined }} aria-pressed={range === option.value}>
             {option.label}
           </button>
         ))}
       </div>
 
-      <div className="mb-1.5 grid grid-cols-3 rounded-full border border-slate-200 bg-white p-0.5 dark:border-slate-700 dark:bg-slate-900/60 sm:mb-4 sm:p-1">
+      <div className="mb-1.5 grid grid-cols-4 rounded-full border border-slate-200 bg-white p-0.5 dark:border-slate-700 dark:bg-slate-900/60 sm:mb-4 sm:p-1">
         {METRIC_OPTIONS.map((option) => (
-          <button
-            key={option.value}
-            type="button"
-            onClick={() => setMetric(option.value)}
-            className="rounded-full px-3 py-0.5 text-xs font-medium transition sm:py-2 sm:text-sm sm:font-black"
-            style={{
-              backgroundColor: metric === option.value ? `${theme.primary}22` : 'transparent',
-              color: metric === option.value ? theme.text : undefined,
-              boxShadow: metric === option.value ? `inset 0 0 0 1px ${theme.primary}66` : undefined,
-            }}
-            aria-pressed={metric === option.value}
-          >
+          <button key={option.value} type="button" onClick={() => setMetric(option.value)} className="rounded-full px-2 py-0.5 text-[0.68rem] font-medium transition sm:px-3 sm:py-2 sm:text-sm sm:font-black" style={{ backgroundColor: metric === option.value ? `${theme.primary}22` : 'transparent', color: metric === option.value ? theme.text : undefined, boxShadow: metric === option.value ? `inset 0 0 0 1px ${theme.primary}66` : undefined }} aria-pressed={metric === option.value}>
             {option.label}
           </button>
         ))}
       </div>
 
       {degradedReason ? (
-        <div className="rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800" role="status">
-          {degradedReason}
-        </div>
+        <div className="rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800" role="status">{degradedReason}</div>
       ) : !hasEnoughPointsForChart ? (
         <div className="rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 text-center text-xs text-slate-600 dark:border-slate-700 dark:bg-slate-900/40 dark:text-slate-300 sm:px-4 sm:py-6 sm:text-sm" role="status">
-          {loading ? 'Cargando historico disponible...' : 'Aun no hay suficientes mediciones para graficar esta metrica.'}
+          {loading ? 'Cargando historico disponible...' : getInsufficientDataCopy(metric)}
         </div>
       ) : (
-        <div
-          className="h-24 w-full sm:h-56"
-          style={{ color: theme.secondary }}
-          aria-label={`Grafica historica de ${metricConfig.label} para ${cityName}`}
-        >
+        <div className="h-24 w-full sm:h-56" style={{ color: theme.secondary }} aria-label={`Grafica historica de ${metricConfig.label} para ${cityName}`}>
           <ResponsiveContainer width="100%" height="100%">
             <LineChart data={chartPoints} margin={{ top: 4, right: 6, left: -20, bottom: -4 }}>
               <CartesianGrid strokeDasharray="3 3" vertical={false} />
               <XAxis dataKey="label" tick={{ fontSize: 10 }} minTickGap={24} />
               <YAxis tick={{ fontSize: 10 }} width={36} domain={['auto', 'auto']} />
-              <Tooltip
-                labelFormatter={(_, payload) => {
-                  const point = payload?.[0]?.payload as ChartPoint | undefined;
-                  return point
-                    ? formatNullableTimestamp(point.timestamp, {
-                        dateStyle: 'medium',
-                        timeStyle: range === '6m' ? undefined : 'short',
-                      })
-                    : 'Medicion';
-                }}
-                formatter={(value) => [`${value}${metricConfig.suffix}`, metricConfig.label]}
-              />
-              <Line
-                type="monotone"
-                dataKey="value"
-                stroke="currentColor"
-                strokeWidth={3}
-                dot={range === '24h'}
-                connectNulls={false}
-                isAnimationActive={false}
-              />
+              <Tooltip labelFormatter={(_, payload) => {
+                const point = payload?.[0]?.payload as ChartPoint | undefined;
+                return point ? formatNullableTimestamp(point.timestamp, { dateStyle: 'medium', timeStyle: range === '6m' ? undefined : 'short' }) : 'Medicion';
+              }} formatter={(value) => [`${value}${metricConfig.suffix}`, metricConfig.label]} />
+              <Line type="monotone" dataKey="value" stroke="currentColor" strokeWidth={3} dot={range === '24h'} connectNulls={false} isAnimationActive={false} />
             </LineChart>
           </ResponsiveContainer>
         </div>
       )}
 
-      <p className="mt-0.5 text-[0.66rem] font-medium text-slate-500 dark:text-slate-300 sm:mt-3 sm:text-sm">
-        Basado en {getMetricCopy(metric, range)}.
-      </p>
+      <p className="mt-0.5 text-[0.66rem] font-medium text-slate-500 dark:text-slate-300 sm:mt-3 sm:text-sm">Basado en {getMetricCopy(metric, range)}.</p>
 
       <div className="mt-4 hidden rounded-xl border border-slate-200 bg-slate-50 p-4 dark:border-slate-700 dark:bg-slate-900/40 md:block">
         <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
           <div>
-            <p className="text-xs font-semibold uppercase tracking-wider text-slate-500 dark:text-slate-400">
-              Contaminante dominante
-            </p>
+            <p className="text-xs font-semibold uppercase tracking-wider text-slate-500 dark:text-slate-400">Contaminante dominante</p>
             <p className="text-sm font-medium text-slate-800 dark:text-slate-100">
-              {dominantPollutant
-                ? `${dominantPollutant.pollutant} fue dominante en ${dominantPollutant.percentage}% de las mediciones.`
-                : 'Sin datos suficientes de contaminante dominante.'}
+              {dominantPollutant ? `${dominantPollutant.pollutant} fue dominante en ${dominantPollutant.percentage}% de las mediciones.` : 'Sin datos suficientes de contaminante dominante.'}
             </p>
           </div>
           <p className="text-xs text-slate-500 dark:text-slate-400">{cityName}</p>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -30,6 +30,11 @@ export interface AirQualityHistoryRow {
   main_pollutant_us: string | null;
   temperature_c: number | null;
   humidity_percent: number | null;
+  weather_temperature_c: number | null;
+  weather_humidity_percent: number | null;
+  weather_wind_speed_kmh: number | null;
+  weather_timestamp: string | null;
+  weather_provider: string | null;
 }
 
 export interface AirQualityDailyHistoryRow {
@@ -40,13 +45,21 @@ export interface AirQualityDailyHistoryRow {
   max_aqi_us: number | null;
   avg_temperature_c: number | null;
   avg_humidity_percent: number | null;
+  avg_weather_temperature_c: number | null;
+  avg_weather_humidity_percent: number | null;
+  avg_weather_wind_speed_kmh: number | null;
   dominant_pollutant_us: string | null;
   reading_count: number;
+  weather_reading_count: number;
 }
 
 export type AirQualityTrend = 'rising' | 'falling' | 'stable' | 'insufficient-data';
 
-export type AirQualityHistoryMetric = 'aqi_us' | 'temperature_c' | 'humidity_percent';
+export type AirQualityHistoryMetric =
+  | 'aqi_us'
+  | 'weather_temperature_c'
+  | 'weather_humidity_percent'
+  | 'weather_wind_speed_kmh';
 
 export type AirQualityDataQuality = 'fresh' | 'degraded';
 
@@ -96,7 +109,14 @@ export interface AirQualityData {
   weather_timestamp?: string | null;
 }
 
-export type AirQualityStatus = 'good' | 'moderate' | 'unhealthy-sensitive' | 'unhealthy' | 'very-unhealthy' | 'hazardous' | 'unknown';
+export type AirQualityStatus =
+  | 'good'
+  | 'moderate'
+  | 'unhealthy-sensitive'
+  | 'unhealthy'
+  | 'very-unhealthy'
+  | 'hazardous'
+  | 'unknown';
 
 export interface HistoricalData {
   date: string;


### PR DESCRIPTION
Updates the historical trend UI to consume canonical weather history fields now available from the Supabase RPCs.

Changes:
- Temperature uses weather_temperature_c / avg_weather_temperature_c
- Humidity uses weather_humidity_percent / avg_weather_humidity_percent
- Wind uses weather_wind_speed_kmh / avg_weather_wind_speed_kmh
- No fallback to legacy WAQI weather fields

Guardrails:
- app/frontend only
- no AQI changes
- no geolocation changes
- no pipeline changes
- no secrets