### PR TITLE
feat: add Desahogate civic campaign CTA

### DIFF
--- a/src/pages/Asociaciones.tsx
+++ b/src/pages/Asociaciones.tsx
@@ -291,6 +291,38 @@ export default function Asociaciones() {
           ))}
         </div>
 
+        <motion.section
+          className="mb-12 overflow-hidden rounded-2xl border border-amber-200 bg-gradient-to-br from-amber-50 via-white to-sky-50 p-6 shadow-lg dark:border-amber-700/50 dark:from-slate-800 dark:via-slate-800 dark:to-slate-900"
+          initial={{ opacity: 0, y: 12 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.35 }}
+        >
+          <div className="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
+            <div className="max-w-3xl">
+              <p className="mb-2 text-xs font-black uppercase tracking-[0.24em] text-amber-700 dark:text-amber-300">
+                Campaña ciudadana activa
+              </p>
+              <h2 className="mb-3 text-2xl font-black text-slate-950 dark:text-white md:text-3xl">
+                Desahógate: Consulta Pública por el aire limpio en Nuevo León
+              </h2>
+              <p className="text-sm leading-6 text-slate-700 dark:text-slate-300 md:text-base">
+                Si quieres pasar de informarte a participar, esta campaña reúne puntos para firmar, voluntariado, documentos y preguntas frecuentes sobre la consulta pública por el aire limpio.
+              </p>
+            </div>
+            <a
+              href="https://linktr.ee/sisepuedenuevoleon"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex shrink-0 items-center justify-center rounded-full bg-slate-950 px-5 py-3 text-sm font-black text-white shadow-md transition hover:-translate-y-0.5 hover:bg-slate-800 dark:bg-white dark:text-slate-950 dark:hover:bg-slate-200"
+            >
+              Ver cómo participar <IoArrowForwardOutline className="ml-2" />
+            </a>
+          </div>
+          <p className="mt-4 text-xs text-slate-500 dark:text-slate-400">
+            Referencia ciudadana externa. MtyRespira no procesa firmas ni datos personales de esta campaña.
+          </p>
+        </motion.section>
+
         <div className="mb-12 rounded-lg bg-green-50 p-8 dark:bg-green-900/20">
           <h2 className="mb-4 text-2xl font-bold text-green-800 dark:text-green-400">¿Cómo puedo contribuir?</h2>
           <div className="grid grid-cols-1 gap-6 md:grid-cols-3">

--- a/src/pages/Asociaciones.tsx
+++ b/src/pages/Asociaciones.tsx
@@ -160,9 +160,12 @@ export default function Asociaciones() {
           <p className="mb-8 max-w-3xl text-lg md:text-xl">
             Estas organizaciones trabajan activamente para mejorar la calidad del aire en Monterrey y su área metropolitana. Conoce su labor y descubre cómo puedes contribuir a esta importante causa.
           </p>
-          <button className="flex items-center rounded-md bg-white px-6 py-3 font-semibold text-blue-600 shadow-md transition-colors hover:bg-opacity-90">
+          <a
+            href="#desahogate"
+            className="inline-flex items-center rounded-md bg-white px-6 py-3 font-semibold text-blue-600 shadow-md transition-colors hover:bg-opacity-90 focus:outline-none focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-amber-500"
+          >
             ¿Cómo puedo ayudar? <IoArrowForwardOutline className="ml-2" />
-          </button>
+          </a>
         </div>
 
         <div className="mb-12 grid grid-cols-1 gap-8 md:grid-cols-2 lg:grid-cols-2">
@@ -292,7 +295,8 @@ export default function Asociaciones() {
         </div>
 
         <motion.section
-          className="mb-12 overflow-hidden rounded-2xl border border-amber-200 bg-gradient-to-br from-amber-50 via-white to-sky-50 p-6 shadow-lg dark:border-amber-700/50 dark:from-slate-800 dark:via-slate-800 dark:to-slate-900"
+          id="desahogate"
+          className="mb-12 scroll-mt-24 overflow-hidden rounded-2xl border border-amber-200 bg-gradient-to-br from-amber-50 via-white to-sky-50 p-6 shadow-lg dark:border-amber-700/50 dark:from-slate-800 dark:via-slate-800 dark:to-slate-900"
           initial={{ opacity: 0, y: 12 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.35 }}


### PR DESCRIPTION
## Summary
- Adds a civic campaign CTA to `/asociaciones` for Desahógate / Consulta Pública por el aire limpio en Nuevo León.
- Links to the external Linktree provided by the campaign.
- Frames it as an external citizen reference, not a formal association partnership.

## Scope
- Frontend-only UX content.
- No Supabase changes.
- No AQI/provider/pipeline/geolocation changes.
- No secrets.

## Notes
This complements the associations page with a concrete participation path found in Monterrey while keeping MtyRespira out of signature/data collection flows.