### PR TITLE
ux: clarify hero messaging and cta wiring

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,12 +9,23 @@ import PrivacyPolicy from './pages/PrivacyPolicy';
 import './App.css';
 
 // Componente que se asegura de que la página se desplace hacia arriba al navegar
+// y respeta anchors internos como /asociaciones#desahogate.
 function ScrollToTop() {
-  const { pathname } = useLocation();
+  const { pathname, hash } = useLocation();
 
   useEffect(() => {
-    window.scrollTo(0, 0);
-  }, [pathname]);
+    if (!hash) {
+      window.scrollTo(0, 0);
+      return;
+    }
+
+    const elementId = decodeURIComponent(hash.replace('#', ''));
+    const scrollToHashElement = () => {
+      document.getElementById(elementId)?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    };
+
+    window.requestAnimationFrame(scrollToHashElement);
+  }, [pathname, hash]);
 
   return null;
 }

--- a/src/pages/Asociaciones.tsx
+++ b/src/pages/Asociaciones.tsx
@@ -155,17 +155,71 @@ export default function Asociaciones() {
   return (
     <Layout>
       <div className="mx-auto max-w-7xl">
-        <div className={`${getHeaderColorClass()} mb-12 rounded-lg px-8 py-12 text-white shadow-lg`}>
-          <h1 className="mb-4 text-3xl font-bold md:text-5xl">¡Únete al movimiento por un aire más limpio!</h1>
+        <div className={`${getHeaderColorClass()} mb-12 rounded-lg px-6 py-10 text-white shadow-lg sm:px-8 sm:py-12`}>
+          <h1 className="mb-4 text-3xl font-bold md:text-5xl">Participa por un aire más limpio</h1>
           <p className="mb-8 max-w-3xl text-lg md:text-xl">
-            Estas organizaciones trabajan activamente para mejorar la calidad del aire en Monterrey y su área metropolitana. Conoce su labor y descubre cómo puedes contribuir a esta importante causa.
+            Explora organizaciones, recursos ciudadanos y una campaña externa para pasar de consultar
+            datos a tomar acción informada por la calidad del aire en Nuevo León.
           </p>
           <a
             href="#desahogate"
-            className="inline-flex items-center rounded-md bg-white px-6 py-3 font-semibold text-blue-600 shadow-md transition-colors hover:bg-opacity-90 focus:outline-none focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-amber-500"
+            className="inline-flex items-center rounded-md bg-white px-5 py-3 text-sm font-semibold text-blue-600 shadow-md transition-colors hover:bg-opacity-90 focus:outline-none focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-amber-500 sm:px-6 sm:text-base"
           >
-            ¿Cómo puedo ayudar? <IoArrowForwardOutline className="ml-2" />
+            Ver campaña ciudadana <IoArrowForwardOutline className="ml-2" />
           </a>
+        </div>
+
+        <motion.section
+          id="desahogate"
+          className="mb-12 scroll-mt-24 overflow-hidden rounded-2xl border border-amber-200 bg-gradient-to-br from-amber-50 via-white to-sky-50 p-6 shadow-lg dark:border-amber-700/50 dark:from-slate-800 dark:via-slate-800 dark:to-slate-900"
+          initial={{ opacity: 0, y: 12 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.35 }}
+        >
+          <div className="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
+            <div className="max-w-3xl">
+              <p className="mb-2 text-xs font-black uppercase tracking-[0.24em] text-amber-700 dark:text-amber-300">
+                Acción ciudadana externa
+              </p>
+              <h2 className="mb-3 text-2xl font-black text-slate-950 dark:text-white md:text-3xl">
+                Desahógate: Consulta Pública por el aire limpio en Nuevo León
+              </h2>
+              <p className="text-sm leading-6 text-slate-700 dark:text-slate-300 md:text-base">
+                Consulta puntos para firmar, voluntariado, documentos y preguntas frecuentes publicados por
+                la campaña ciudadana. MtyRespira solo referencia este recurso para facilitar participación informada.
+              </p>
+            </div>
+            <a
+              href="https://linktr.ee/sisepuedenuevoleon"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex shrink-0 items-center justify-center rounded-full bg-slate-950 px-5 py-3 text-sm font-black text-white shadow-md transition hover:-translate-y-0.5 hover:bg-slate-800 dark:bg-white dark:text-slate-950 dark:hover:bg-slate-200"
+            >
+              Abrir opciones de participación <IoArrowForwardOutline className="ml-2" />
+            </a>
+          </div>
+          <p className="mt-4 text-xs text-slate-500 dark:text-slate-400">
+            Referencia ciudadana externa. MtyRespira no procesa firmas ni datos personales de esta campaña
+            y no afirma afiliación formal con sus organizadores.
+          </p>
+        </motion.section>
+
+        <div className="mb-12 rounded-lg bg-green-50 p-6 dark:bg-green-900/20 sm:p-8">
+          <h2 className="mb-4 text-2xl font-bold text-green-800 dark:text-green-400">Tres formas claras de contribuir</h2>
+          <div className="grid grid-cols-1 gap-6 md:grid-cols-3">
+            <motion.div whileHover={{ scale: 1.03 }} transition={{ type: 'spring', stiffness: 300 }} className="rounded-lg bg-white p-6 shadow dark:bg-slate-800">
+              <h3 className="mb-2 text-lg font-semibold text-gray-900 dark:text-white">Infórmate</h3>
+              <p className="text-gray-600 dark:text-gray-300">Consulta lecturas disponibles, revisa fuentes oficiales y comparte información verificable con tu comunidad.</p>
+            </motion.div>
+            <motion.div whileHover={{ scale: 1.03 }} transition={{ type: 'spring', stiffness: 300 }} className="rounded-lg bg-white p-6 shadow dark:bg-slate-800">
+              <h3 className="mb-2 text-lg font-semibold text-gray-900 dark:text-white">Participa</h3>
+              <p className="text-gray-600 dark:text-gray-300">Revisa campañas, eventos o convocatorias publicadas por organizaciones y colectivos ciudadanos.</p>
+            </motion.div>
+            <motion.div whileHover={{ scale: 1.03 }} transition={{ type: 'spring', stiffness: 300 }} className="rounded-lg bg-white p-6 shadow dark:bg-slate-800">
+              <h3 className="mb-2 text-lg font-semibold text-gray-900 dark:text-white">Conecta</h3>
+              <p className="text-gray-600 dark:text-gray-300">Visita los canales públicos de cada organización para conocer necesidades, voluntariado o donativos.</p>
+            </motion.div>
+          </div>
         </div>
 
         <div className="mb-12 grid grid-cols-1 gap-8 md:grid-cols-2 lg:grid-cols-2">
@@ -267,7 +321,7 @@ export default function Asociaciones() {
                           rel="noopener noreferrer"
                           className="flex items-center text-sm transition-colors hover:text-blue-500"
                         >
-                          Sitio Web <IoArrowForwardOutline className="ml-1 opacity-0 transition-opacity group-hover:opacity-100" />
+                          Sitio oficial <IoArrowForwardOutline className="ml-1 opacity-0 transition-opacity group-hover:opacity-100" />
                         </a>
                       </div>
                     )}
@@ -275,74 +329,25 @@ export default function Asociaciones() {
                 </div>
               </div>
 
-              <motion.div
-                className={`${getHeaderColorClass()} px-6 py-4 text-white`}
-                whileHover={{ scale: 1.02 }}
-                transition={{ type: 'spring', stiffness: 500 }}
-              >
-                <a
-                  href={asociacion.sitioWeb}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="flex items-center justify-between font-medium text-white"
+              {asociacion.sitioWeb && (
+                <motion.div
+                  className={`${getHeaderColorClass()} px-6 py-4 text-white`}
+                  whileHover={{ scale: 1.02 }}
+                  transition={{ type: 'spring', stiffness: 500 }}
                 >
-                  <span>Visitar organización</span>
-                  <IoArrowForwardOutline className="ml-2" />
-                </a>
-              </motion.div>
+                  <a
+                    href={asociacion.sitioWeb}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="flex items-center justify-between font-medium text-white"
+                  >
+                    <span>Conocer su trabajo</span>
+                    <IoArrowForwardOutline className="ml-2" />
+                  </a>
+                </motion.div>
+              )}
             </motion.div>
           ))}
-        </div>
-
-        <motion.section
-          id="desahogate"
-          className="mb-12 scroll-mt-24 overflow-hidden rounded-2xl border border-amber-200 bg-gradient-to-br from-amber-50 via-white to-sky-50 p-6 shadow-lg dark:border-amber-700/50 dark:from-slate-800 dark:via-slate-800 dark:to-slate-900"
-          initial={{ opacity: 0, y: 12 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.35 }}
-        >
-          <div className="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
-            <div className="max-w-3xl">
-              <p className="mb-2 text-xs font-black uppercase tracking-[0.24em] text-amber-700 dark:text-amber-300">
-                Campaña ciudadana activa
-              </p>
-              <h2 className="mb-3 text-2xl font-black text-slate-950 dark:text-white md:text-3xl">
-                Desahógate: Consulta Pública por el aire limpio en Nuevo León
-              </h2>
-              <p className="text-sm leading-6 text-slate-700 dark:text-slate-300 md:text-base">
-                Si quieres pasar de informarte a participar, esta campaña reúne puntos para firmar, voluntariado, documentos y preguntas frecuentes sobre la consulta pública por el aire limpio.
-              </p>
-            </div>
-            <a
-              href="https://linktr.ee/sisepuedenuevoleon"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex shrink-0 items-center justify-center rounded-full bg-slate-950 px-5 py-3 text-sm font-black text-white shadow-md transition hover:-translate-y-0.5 hover:bg-slate-800 dark:bg-white dark:text-slate-950 dark:hover:bg-slate-200"
-            >
-              Ver cómo participar <IoArrowForwardOutline className="ml-2" />
-            </a>
-          </div>
-          <p className="mt-4 text-xs text-slate-500 dark:text-slate-400">
-            Referencia ciudadana externa. MtyRespira no procesa firmas ni datos personales de esta campaña.
-          </p>
-        </motion.section>
-
-        <div className="mb-12 rounded-lg bg-green-50 p-8 dark:bg-green-900/20">
-          <h2 className="mb-4 text-2xl font-bold text-green-800 dark:text-green-400">¿Cómo puedo contribuir?</h2>
-          <div className="grid grid-cols-1 gap-6 md:grid-cols-3">
-            <motion.div whileHover={{ scale: 1.03 }} transition={{ type: 'spring', stiffness: 300 }} className="rounded-lg bg-white p-6 shadow dark:bg-slate-800">
-              <h3 className="mb-2 text-lg font-semibold text-gray-900 dark:text-white">Infórmate</h3>
-              <p className="text-gray-600 dark:text-gray-300">Conoce la situación de la calidad del aire en tu ciudad y comparte información confiable con tu comunidad.</p>
-            </motion.div>
-            <motion.div whileHover={{ scale: 1.03 }} transition={{ type: 'spring', stiffness: 300 }} className="rounded-lg bg-white p-6 shadow dark:bg-slate-800">
-              <h3 className="mb-2 text-lg font-semibold text-gray-900 dark:text-white">Participa en actividades</h3>
-              <p className="text-gray-600 dark:text-gray-300">Únete a jornadas de reforestación, talleres de concientización y eventos organizados por estas asociaciones.</p>
-            </motion.div>
-            <motion.div whileHover={{ scale: 1.03 }} transition={{ type: 'spring', stiffness: 300 }} className="rounded-lg bg-white p-6 shadow dark:bg-slate-800">
-              <h3 className="mb-2 text-lg font-semibold text-gray-900 dark:text-white">Dona o voluntariza</h3>
-              <p className="text-gray-600 dark:text-gray-300">Apoya con recursos económicos o tu tiempo como voluntario para fortalecer estas iniciativas ciudadanas.</p>
-            </motion.div>
-          </div>
         </div>
       </div>
     </Layout>

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -161,24 +161,33 @@ export default function Dashboard() {
       >
         <div className="flex flex-col items-start justify-between gap-4 md:flex-row md:items-center">
           <div className="md:mr-6">
-            <h2 className="mb-2 text-[1.1rem] font-bold leading-tight sm:mb-3 sm:text-2xl">Quieres ayudar a mejorar la calidad del aire?</h2>
+            <h2 className="mb-2 text-[1.1rem] font-bold leading-tight sm:mb-3 sm:text-2xl">
+              ¿Quieres actuar por un aire más limpio?
+            </h2>
             <p className="mb-0 text-sm text-gray-600 dark:text-gray-300 sm:mb-4 sm:text-base">
-              Conoce las asociaciones y organizaciones que trabajan activamente para mejorar el aire que respiramos en Monterrey y su area metropolitana.
+              Consulta organizaciones, recursos ciudadanos y una campaña externa con opciones para firmar,
+              voluntariar o informarte sin compartir datos con MtyRespira.
             </p>
           </div>
           <Link
-            to="/asociaciones"
+            to="/asociaciones#desahogate"
             className={`inline-flex items-center rounded-lg px-4 py-2.5 text-sm font-medium transition-colors sm:px-6 sm:py-3 sm:text-lg ${getStatusButtonClass()}`}
           >
-            Unete al movimiento <IoArrowForwardOutline className="ml-2" />
+            Ver formas de participar <IoArrowForwardOutline className="ml-2" />
           </Link>
         </div>
       </motion.div>
 
       <div className="mt-8">
-        <h2 className="mb-4 text-[1.05rem] font-bold sm:mb-6 sm:text-xl" style={{ color: theme?.text }}>Recursos para cuidar nuestra calidad del aire</h2>
+        <h2 className="mb-4 text-[1.05rem] font-bold sm:mb-6 sm:text-xl" style={{ color: theme?.text }}>
+          Recursos para cuidar nuestra calidad del aire
+        </h2>
         <div className="grid grid-cols-1 gap-4 md:grid-cols-3 sm:gap-6">
-          <Link to="https://www.who.int/es/news-room/fact-sheets/detail/ambient-(outdoor)-air-quality-and-health" target="_blank">
+          <a
+            href="https://www.who.int/es/news-room/fact-sheets/detail/ambient-(outdoor)-air-quality-and-health"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
             <motion.div
               whileHover={{ y: -5 }}
               transition={{ type: 'spring', stiffness: 300 }}
@@ -189,15 +198,17 @@ export default function Dashboard() {
                 <div className="mb-3 flex h-12 w-12 items-center justify-center rounded-full sm:mb-4 sm:h-16 sm:w-16" style={{ backgroundColor: theme?.primary }}>
                   <IoEarthOutline className="h-6 w-6 text-white sm:h-8 sm:w-8" />
                 </div>
-                <h3 className="mb-2 text-base font-semibold sm:mb-3 sm:text-lg" style={{ color: theme?.text }}>Monitoreo Ambiental</h3>
+                <h3 className="mb-2 text-base font-semibold sm:mb-3 sm:text-lg" style={{ color: theme?.text }}>
+                  Entender el AQI
+                </h3>
                 <p className="text-sm text-gray-600 dark:text-gray-300">
-                  Accede a datos de monitoreo ambiental y aprende a interpretar los indices de calidad del aire y su impacto en la salud.
+                  Lee una guía de salud ambiental para interpretar la contaminación del aire y sus riesgos.
                 </p>
               </div>
             </motion.div>
-          </Link>
+          </a>
 
-          <Link to="http://aire.nl.gob.mx/map_calidad.html" target="_blank">
+          <a href="http://aire.nl.gob.mx/map_calidad.html" target="_blank" rel="noopener noreferrer">
             <motion.div
               whileHover={{ y: -5 }}
               transition={{ type: 'spring', stiffness: 300 }}
@@ -208,15 +219,21 @@ export default function Dashboard() {
                 <div className="mb-3 flex h-12 w-12 items-center justify-center rounded-full sm:mb-4 sm:h-16 sm:w-16" style={{ backgroundColor: theme?.primary }}>
                   <IoLeafOutline className="h-6 w-6 text-white sm:h-8 sm:w-8" />
                 </div>
-                <h3 className="mb-2 text-base font-semibold sm:mb-3 sm:text-lg" style={{ color: theme?.text }}>Acciones Cotidianas</h3>
+                <h3 className="mb-2 text-base font-semibold sm:mb-3 sm:text-lg" style={{ color: theme?.text }}>
+                  Consultar red oficial
+                </h3>
                 <p className="text-sm text-gray-600 dark:text-gray-300">
-                  Descubre que puedes hacer en tu dia a dia para contribuir a mejorar la calidad del aire en tu comunidad.
+                  Abre el mapa oficial de calidad del aire de Nuevo León para comparar lecturas públicas.
                 </p>
               </div>
             </motion.div>
-          </Link>
+          </a>
 
-          <Link to="https://www.gob.mx/cofepris/documentos/protegete-de-la-contaminacion-ambiental" target="_blank">
+          <a
+            href="https://www.gob.mx/cofepris/documentos/protegete-de-la-contaminacion-ambiental"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
             <motion.div
               whileHover={{ y: -5 }}
               transition={{ type: 'spring', stiffness: 300 }}
@@ -227,13 +244,15 @@ export default function Dashboard() {
                 <div className="mb-3 flex h-12 w-12 items-center justify-center rounded-full sm:mb-4 sm:h-16 sm:w-16" style={{ backgroundColor: theme?.primary }}>
                   <IoHelpBuoyOutline className="h-6 w-6 text-white sm:h-8 sm:w-8" />
                 </div>
-                <h3 className="mb-2 text-base font-semibold sm:mb-3 sm:text-lg" style={{ color: theme?.text }}>Proteccion Personal</h3>
+                <h3 className="mb-2 text-base font-semibold sm:mb-3 sm:text-lg" style={{ color: theme?.text }}>
+                  Protegerte en mala calidad
+                </h3>
                 <p className="text-sm text-gray-600 dark:text-gray-300">
-                  Medidas de proteccion personal y familiar durante episodios de contaminacion elevada del aire.
+                  Revisa medidas personales y familiares para episodios de contaminación elevada.
                 </p>
               </div>
             </motion.div>
-          </Link>
+          </a>
         </div>
       </div>
 
@@ -241,7 +260,7 @@ export default function Dashboard() {
         <h2 className="mb-3 text-[1.05rem] font-bold text-gray-900 dark:text-white sm:mb-4 sm:text-xl">Fuentes de Datos</h2>
 
         <div className="text-sm text-gray-600 dark:text-gray-400">
-          <p>Esta aplicacion integra y procesa datos de multiples fuentes para proporcionar informacion completa sobre la calidad del aire en Monterrey:</p>
+          <p>Esta aplicación integra y procesa datos de múltiples fuentes para presentar lecturas disponibles de calidad del aire en Monterrey:</p>
 
           <ul className="mt-3 list-disc space-y-2 pl-5">
             <li>
@@ -255,7 +274,7 @@ export default function Dashboard() {
           </ul>
 
           <p className={`mt-4 rounded-lg p-3 ${getStatusButtonClass().replace('bg-', 'bg-').replace('hover:bg-', 'bg-').replace('text-white', `bg-opacity-10 ${getStatusBorderClass().replace('border-', 'text-')}`)}`}>
-            La tarjeta principal muestra la hora de medicion y la ultima actualizacion del pipeline cuando aplica.
+            La tarjeta principal muestra la hora de medición y la última actualización del pipeline cuando aplica.
           </p>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Clarifies the Home civic-action CTA so users know it leads to concrete participation options.
- Wires the Home CTA directly to `/asociaciones#desahogate`.
- Restores SPA hash scrolling in `ScrollToTop` so `/asociaciones#desahogate` lands on the campaign block instead of the top of the page.
- Moves the external citizen-action campaign block higher on `/asociaciones` so the anchor lands on useful content immediately.
- Rewrites ambiguous CTA/microcopy toward citizen-facing actions: participate, connect, understand AQI, consult official network, and protect yourself.
- Adds/keeps `target="_blank"` and `rel="noopener noreferrer"` on external links.
- Keeps explicit transparency that MtyRespira does not process signatures or personal data for the external campaign and does not claim formal affiliation.

## Validation
- Pending GitHub Actions / local handoff:
  - `npm run lint`
  - `npm run typecheck`
  - `npm run build`
- Manual review target:
  - `/` mobile at 390px minimum: CTA should not truncate or overflow.
  - `/asociaciones` mobile at 390px minimum: `#desahogate` anchor should land on the external campaign/action block and all visible CTAs should have real actions.

## Screenshots / mobile notes
- Not captured in this connector session. Please capture after preview deploy or local run.

## Safety / scope confirmation
- No Supabase changes.
- No pipeline changes.
- No AQI/provider changes.
- No geolocation changes.
- No data contract changes.
- No secrets or `service_role` added to frontend/app.
- No environmental data invented.
- No real-time monitoring claim added.