### PR TITLE
ux: improve associations contrast and focus states

### DIFF
--- a/src/pages/Asociaciones.tsx
+++ b/src/pages/Asociaciones.tsx
@@ -92,10 +92,13 @@ const asociaciones: Asociacion[] = [
   },
 ];
 
+const focusRingClass =
+  'focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-sky-300 focus-visible:ring-offset-2 dark:focus-visible:ring-sky-500 dark:focus-visible:ring-offset-slate-900';
+
 export default function Asociaciones() {
   const { theme } = useAirQuality();
 
-  const getHeaderColorClass = () => {
+  const getAccentBarClass = () => {
     if (!theme) return 'bg-gradient-to-r from-blue-600 to-teal-500';
 
     switch (theme.primary) {
@@ -121,7 +124,7 @@ export default function Asociaciones() {
 
   const renderLogo = (asociacion: Asociacion) => (
     <div
-      className="flex h-16 w-16 shrink-0 items-center justify-center rounded-2xl border border-white/70 bg-gradient-to-br from-sky-100 via-white to-emerald-100 px-2 text-center text-sm font-black leading-none text-slate-700 shadow-md ring-1 ring-slate-200 dark:border-slate-600 dark:from-slate-700 dark:via-slate-800 dark:to-slate-700 dark:text-white dark:ring-slate-600"
+      className="flex h-16 w-16 shrink-0 items-center justify-center rounded-2xl border border-white/70 bg-gradient-to-br from-sky-100 via-white to-emerald-100 px-2 text-center text-sm font-black leading-none text-slate-800 shadow-md ring-1 ring-slate-300 dark:border-slate-600 dark:from-slate-700 dark:via-slate-800 dark:to-slate-700 dark:text-white dark:ring-slate-600"
       aria-label={`Identificador visual de ${asociacion.nombre}`}
       title={asociacion.nombre}
     >
@@ -132,15 +135,20 @@ export default function Asociaciones() {
   return (
     <Layout>
       <div className="mx-auto max-w-7xl">
-        <div className={`${getHeaderColorClass()} mb-12 rounded-lg px-6 py-10 text-white shadow-lg sm:px-8 sm:py-12`}>
-          <h1 className="mb-4 text-3xl font-bold md:text-5xl">Participa por un aire más limpio</h1>
-          <p className="mb-8 max-w-3xl text-lg md:text-xl">
+        <div className="mb-12 rounded-2xl bg-gradient-to-br from-slate-950 via-slate-900 to-sky-950 px-6 py-10 text-white shadow-lg ring-1 ring-white/10 sm:px-8 sm:py-12">
+          <p className="mb-3 text-xs font-black uppercase tracking-[0.24em] text-sky-200">
+            Acción ciudadana
+          </p>
+          <h1 className="mb-4 text-3xl font-black leading-tight md:text-5xl">
+            Participa por un aire más limpio
+          </h1>
+          <p className="mb-8 max-w-3xl text-base leading-7 text-slate-100 md:text-xl md:leading-8">
             Explora organizaciones, recursos ciudadanos y una campaña externa para pasar de consultar
             datos a tomar acción informada por la calidad del aire en Nuevo León.
           </p>
           <a
             href="#desahogate"
-            className="inline-flex items-center rounded-md bg-white px-5 py-3 text-sm font-semibold text-blue-600 shadow-md transition-colors hover:bg-opacity-90 focus:outline-none focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-amber-500 sm:px-6 sm:text-base"
+            className={`inline-flex items-center rounded-md bg-white px-5 py-3 text-sm font-bold text-slate-950 shadow-md transition-colors hover:bg-slate-100 sm:px-6 sm:text-base ${focusRingClass}`}
           >
             Ver campaña ciudadana <IoArrowForwardOutline className="ml-2" />
           </a>
@@ -148,20 +156,20 @@ export default function Asociaciones() {
 
         <motion.section
           id="desahogate"
-          className="mb-12 scroll-mt-24 overflow-hidden rounded-2xl border border-amber-200 bg-gradient-to-br from-amber-50 via-white to-sky-50 p-6 shadow-lg dark:border-amber-700/50 dark:from-slate-800 dark:via-slate-800 dark:to-slate-900"
+          className="mb-12 scroll-mt-24 overflow-hidden rounded-2xl border border-amber-300 bg-gradient-to-br from-amber-50 via-white to-sky-50 p-6 shadow-lg dark:border-amber-700/70 dark:from-slate-800 dark:via-slate-800 dark:to-slate-900"
           initial={{ opacity: 0, y: 12 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.35 }}
         >
           <div className="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
             <div className="max-w-3xl">
-              <p className="mb-2 text-xs font-black uppercase tracking-[0.24em] text-amber-700 dark:text-amber-300">
+              <p className="mb-2 text-xs font-black uppercase tracking-[0.24em] text-amber-800 dark:text-amber-200">
                 Acción ciudadana externa
               </p>
-              <h2 className="mb-3 text-2xl font-black text-slate-950 dark:text-white md:text-3xl">
+              <h2 className="mb-3 text-2xl font-black leading-tight text-slate-950 dark:text-white md:text-3xl">
                 Desahógate: Consulta Pública por el aire limpio en Nuevo León
               </h2>
-              <p className="text-sm leading-6 text-slate-700 dark:text-slate-300 md:text-base">
+              <p className="text-sm leading-6 text-slate-700 dark:text-slate-200 md:text-base">
                 Consulta puntos para firmar, voluntariado, documentos y preguntas frecuentes publicados por
                 la campaña ciudadana. MtyRespira solo referencia este recurso para facilitar participación informada.
               </p>
@@ -170,31 +178,33 @@ export default function Asociaciones() {
               href="https://linktr.ee/sisepuedenuevoleon"
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex shrink-0 items-center justify-center rounded-full bg-slate-950 px-5 py-3 text-sm font-black text-white shadow-md transition hover:-translate-y-0.5 hover:bg-slate-800 dark:bg-white dark:text-slate-950 dark:hover:bg-slate-200"
+              className={`inline-flex shrink-0 items-center justify-center rounded-full bg-slate-950 px-5 py-3 text-sm font-black text-white shadow-md transition hover:-translate-y-0.5 hover:bg-slate-800 dark:bg-white dark:text-slate-950 dark:hover:bg-slate-200 ${focusRingClass}`}
             >
               Abrir opciones de participación <IoArrowForwardOutline className="ml-2" />
             </a>
           </div>
-          <p className="mt-4 text-xs text-slate-500 dark:text-slate-400">
+          <p className="mt-4 rounded-lg bg-white/70 p-3 text-xs leading-5 text-slate-600 dark:bg-slate-900/60 dark:text-slate-300">
             Referencia ciudadana externa. MtyRespira no procesa firmas ni datos personales de esta campaña
             y no afirma afiliación formal con sus organizadores.
           </p>
         </motion.section>
 
-        <div className="mb-12 rounded-lg bg-green-50 p-6 dark:bg-green-900/20 sm:p-8">
-          <h2 className="mb-4 text-2xl font-bold text-green-800 dark:text-green-400">Tres formas claras de contribuir</h2>
+        <div className="mb-12 rounded-2xl border border-green-200 bg-green-50 p-6 dark:border-green-800 dark:bg-green-950/40 sm:p-8">
+          <h2 className="mb-4 text-2xl font-black text-green-900 dark:text-green-100">
+            Tres formas claras de contribuir
+          </h2>
           <div className="grid grid-cols-1 gap-6 md:grid-cols-3">
-            <motion.div whileHover={{ scale: 1.03 }} transition={{ type: 'spring', stiffness: 300 }} className="rounded-lg bg-white p-6 shadow dark:bg-slate-800">
-              <h3 className="mb-2 text-lg font-semibold text-gray-900 dark:text-white">Infórmate</h3>
-              <p className="text-gray-600 dark:text-gray-300">Consulta lecturas disponibles, revisa fuentes oficiales y comparte información verificable con tu comunidad.</p>
+            <motion.div whileHover={{ scale: 1.03 }} transition={{ type: 'spring', stiffness: 300 }} className="rounded-lg bg-white p-6 shadow ring-1 ring-green-100 dark:bg-slate-800 dark:ring-slate-700">
+              <h3 className="mb-2 text-lg font-semibold text-gray-950 dark:text-white">Infórmate</h3>
+              <p className="text-gray-700 dark:text-gray-200">Consulta lecturas disponibles, revisa fuentes oficiales y comparte información verificable con tu comunidad.</p>
             </motion.div>
-            <motion.div whileHover={{ scale: 1.03 }} transition={{ type: 'spring', stiffness: 300 }} className="rounded-lg bg-white p-6 shadow dark:bg-slate-800">
-              <h3 className="mb-2 text-lg font-semibold text-gray-900 dark:text-white">Participa</h3>
-              <p className="text-gray-600 dark:text-gray-300">Revisa campañas, eventos o convocatorias publicadas por organizaciones y colectivos ciudadanos.</p>
+            <motion.div whileHover={{ scale: 1.03 }} transition={{ type: 'spring', stiffness: 300 }} className="rounded-lg bg-white p-6 shadow ring-1 ring-green-100 dark:bg-slate-800 dark:ring-slate-700">
+              <h3 className="mb-2 text-lg font-semibold text-gray-950 dark:text-white">Participa</h3>
+              <p className="text-gray-700 dark:text-gray-200">Revisa campañas, eventos o convocatorias publicadas por organizaciones y colectivos ciudadanos.</p>
             </motion.div>
-            <motion.div whileHover={{ scale: 1.03 }} transition={{ type: 'spring', stiffness: 300 }} className="rounded-lg bg-white p-6 shadow dark:bg-slate-800">
-              <h3 className="mb-2 text-lg font-semibold text-gray-900 dark:text-white">Conecta</h3>
-              <p className="text-gray-600 dark:text-gray-300">Visita los canales públicos de cada organización para conocer necesidades, voluntariado o donativos.</p>
+            <motion.div whileHover={{ scale: 1.03 }} transition={{ type: 'spring', stiffness: 300 }} className="rounded-lg bg-white p-6 shadow ring-1 ring-green-100 dark:bg-slate-800 dark:ring-slate-700">
+              <h3 className="mb-2 text-lg font-semibold text-gray-950 dark:text-white">Conecta</h3>
+              <p className="text-gray-700 dark:text-gray-200">Visita los canales públicos de cada organización para conocer necesidades, voluntariado o donativos.</p>
             </motion.div>
           </div>
         </div>
@@ -203,19 +213,19 @@ export default function Asociaciones() {
           {asociaciones.map((asociacion) => (
             <motion.div
               key={asociacion.id}
-              className="flex h-full min-h-[25rem] flex-col overflow-hidden rounded-2xl bg-white shadow-lg ring-1 ring-slate-100 dark:bg-slate-800 dark:ring-slate-700"
+              className="flex h-full min-h-[25rem] flex-col overflow-hidden rounded-2xl bg-white shadow-lg ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-700"
               whileHover={{ y: -5 }}
               transition={{ type: 'spring', stiffness: 300 }}
             >
-              <div className={`${getHeaderColorClass()} h-2`} />
+              <div className={`${getAccentBarClass()} h-2`} />
 
               <div className="flex flex-1 flex-col p-6">
                 <div className="mb-6 flex flex-col justify-between gap-4 sm:flex-row sm:items-start">
                   <div className="flex min-w-0 items-center gap-4">
                     {renderLogo(asociacion)}
                     <div className="min-w-0">
-                      <h2 className="text-xl font-bold leading-tight text-gray-900 dark:text-white">{asociacion.nombre}</h2>
-                      <p className="mt-1 text-xs font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
+                      <h2 className="text-xl font-bold leading-tight text-gray-950 dark:text-white">{asociacion.nombre}</h2>
+                      <p className="mt-1 text-xs font-semibold uppercase tracking-[0.18em] text-slate-600 dark:text-slate-300">
                         Referencia pública
                       </p>
                     </div>
@@ -227,7 +237,7 @@ export default function Asociaciones() {
                         href={asociacion.redes.facebook}
                         target="_blank"
                         rel="noopener noreferrer"
-                        className="rounded-full bg-gray-100 p-2 text-gray-500 transition-colors hover:bg-blue-100 hover:text-blue-600 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600 dark:hover:text-blue-400"
+                        className={`rounded-full bg-gray-100 p-2 text-gray-600 transition-colors hover:bg-blue-100 hover:text-blue-700 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600 dark:hover:text-blue-300 ${focusRingClass}`}
                         aria-label={`Facebook de ${asociacion.nombre}`}
                         whileHover={{ scale: 1.1 }}
                         whileTap={{ scale: 0.95 }}
@@ -240,7 +250,7 @@ export default function Asociaciones() {
                         href={asociacion.redes.twitter}
                         target="_blank"
                         rel="noopener noreferrer"
-                        className="rounded-full bg-gray-100 p-2 text-gray-500 transition-colors hover:bg-blue-100 hover:text-blue-500 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600 dark:hover:text-blue-400"
+                        className={`rounded-full bg-gray-100 p-2 text-gray-600 transition-colors hover:bg-blue-100 hover:text-blue-700 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600 dark:hover:text-blue-300 ${focusRingClass}`}
                         aria-label={`Twitter/X de ${asociacion.nombre}`}
                         whileHover={{ scale: 1.1 }}
                         whileTap={{ scale: 0.95 }}
@@ -253,7 +263,7 @@ export default function Asociaciones() {
                         href={asociacion.redes.instagram}
                         target="_blank"
                         rel="noopener noreferrer"
-                        className="rounded-full bg-gray-100 p-2 text-gray-500 transition-colors hover:bg-pink-100 hover:text-pink-600 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600 dark:hover:text-pink-400"
+                        className={`rounded-full bg-gray-100 p-2 text-gray-600 transition-colors hover:bg-pink-100 hover:text-pink-700 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600 dark:hover:text-pink-300 ${focusRingClass}`}
                         aria-label={`Instagram de ${asociacion.nombre}`}
                         whileHover={{ scale: 1.1 }}
                         whileTap={{ scale: 0.95 }}
@@ -264,16 +274,16 @@ export default function Asociaciones() {
                   </div>
                 </div>
 
-                <p className="mb-6 flex-1 text-sm leading-6 text-gray-600 dark:text-gray-300">{asociacion.descripcion}</p>
+                <p className="mb-6 flex-1 text-sm leading-6 text-gray-700 dark:text-gray-200">{asociacion.descripcion}</p>
 
                 <div className="border-t border-gray-200 pt-4 dark:border-gray-700">
                   <div className="flex flex-wrap gap-3">
                     {asociacion.contacto.email && (
-                      <div className="group relative inline-flex items-center rounded-md bg-gray-50 px-3 py-2 text-gray-700 transition-colors hover:bg-gray-100 dark:bg-slate-700 dark:text-gray-300 dark:hover:bg-slate-600">
-                        <IoMailOutline className="mr-2 text-gray-500 dark:text-gray-400" />
+                      <div className="group relative inline-flex items-center rounded-md bg-gray-50 px-3 py-2 text-gray-800 transition-colors hover:bg-gray-100 dark:bg-slate-700 dark:text-gray-100 dark:hover:bg-slate-600">
+                        <IoMailOutline className="mr-2 text-gray-600 dark:text-gray-300" />
                         <a
                           href={`mailto:${asociacion.contacto.email}`}
-                          className="max-w-[150px] truncate text-sm transition-colors hover:text-blue-500"
+                          className={`max-w-[150px] truncate text-sm transition-colors hover:text-blue-700 dark:hover:text-blue-300 ${focusRingClass}`}
                           title={asociacion.contacto.email}
                         >
                           {truncateText(asociacion.contacto.email, 15)}
@@ -282,11 +292,11 @@ export default function Asociaciones() {
                     )}
 
                     {asociacion.contacto.telefono && (
-                      <div className="group relative inline-flex items-center rounded-md bg-gray-50 px-3 py-2 text-gray-700 transition-colors hover:bg-gray-100 dark:bg-slate-700 dark:text-gray-300 dark:hover:bg-slate-600">
-                        <IoCallOutline className="mr-2 text-gray-500 dark:text-gray-400" />
+                      <div className="group relative inline-flex items-center rounded-md bg-gray-50 px-3 py-2 text-gray-800 transition-colors hover:bg-gray-100 dark:bg-slate-700 dark:text-gray-100 dark:hover:bg-slate-600">
+                        <IoCallOutline className="mr-2 text-gray-600 dark:text-gray-300" />
                         <a
                           href={`tel:${asociacion.contacto.telefono}`}
-                          className="max-w-[120px] truncate text-sm transition-colors hover:text-blue-500"
+                          className={`max-w-[120px] truncate text-sm transition-colors hover:text-blue-700 dark:hover:text-blue-300 ${focusRingClass}`}
                           title={asociacion.contacto.telefono}
                         >
                           {truncateText(asociacion.contacto.telefono || '', 10)}
@@ -295,13 +305,13 @@ export default function Asociaciones() {
                     )}
 
                     {asociacion.sitioWeb && (
-                      <div className="group inline-flex items-center rounded-md bg-gray-50 px-3 py-2 text-gray-700 transition-colors hover:bg-gray-100 dark:bg-slate-700 dark:text-gray-300 dark:hover:bg-slate-600">
-                        <IoGlobeOutline className="mr-2 text-gray-500 dark:text-gray-400" />
+                      <div className="group inline-flex items-center rounded-md bg-gray-50 px-3 py-2 text-gray-800 transition-colors hover:bg-gray-100 dark:bg-slate-700 dark:text-gray-100 dark:hover:bg-slate-600">
+                        <IoGlobeOutline className="mr-2 text-gray-600 dark:text-gray-300" />
                         <a
                           href={asociacion.sitioWeb}
                           target="_blank"
                           rel="noopener noreferrer"
-                          className="flex items-center text-sm transition-colors hover:text-blue-500"
+                          className={`flex items-center text-sm transition-colors hover:text-blue-700 dark:hover:text-blue-300 ${focusRingClass}`}
                         >
                           Sitio oficial <IoArrowForwardOutline className="ml-1 opacity-0 transition-opacity group-hover:opacity-100" />
                         </a>
@@ -313,7 +323,7 @@ export default function Asociaciones() {
 
               {asociacion.sitioWeb && (
                 <motion.div
-                  className={`${getHeaderColorClass()} px-6 py-4 text-white`}
+                  className="bg-slate-950 px-6 py-4 text-white dark:bg-white dark:text-slate-950"
                   whileHover={{ scale: 1.02 }}
                   transition={{ type: 'spring', stiffness: 500 }}
                 >
@@ -321,7 +331,7 @@ export default function Asociaciones() {
                     href={asociacion.sitioWeb}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="flex items-center justify-between font-medium text-white"
+                    className={`flex items-center justify-between font-bold ${focusRingClass}`}
                   >
                     <span>Conocer su trabajo</span>
                     <IoArrowForwardOutline className="ml-2" />
@@ -332,7 +342,7 @@ export default function Asociaciones() {
           ))}
         </div>
 
-        <p className="mb-12 rounded-xl border border-slate-200 bg-white p-4 text-sm leading-6 text-slate-600 shadow-sm dark:border-slate-700 dark:bg-slate-800 dark:text-slate-300">
+        <p className="mb-12 rounded-xl border border-slate-300 bg-white p-4 text-sm leading-6 text-slate-700 shadow-sm dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200">
           Los identificadores de organizaciones se muestran como iniciales propias de MtyRespira para evitar
           imágenes rotas o dependencias externas. Si se alojan logotipos oficiales en el futuro, deberá existir
           permiso o una fuente pública verificable antes de agregarlos al repositorio.


### PR DESCRIPTION
## Summary
- Implements the first pass of Story 4.2 — Accessibility Contrast + Readability Pass.
- Improves `/asociaciones` hero readability by replacing theme-dependent light gradients with a stable dark, high-contrast surface.
- Adds a shared `focus-visible` treatment for primary CTAs, external campaign links, social links, contact links, and card CTAs.
- Improves contrast on association cards, contact chips, helper notes, and civic-action blocks.
- Keeps the visual identity but avoids low-contrast combinations such as white text over light yellow/amber theme gradients.

## Validation
- Pending GitHub Actions / local handoff:
  - `npm run lint`
  - `npm run typecheck`
  - `npm run build`
- Manual review target:
  - `/asociaciones` at 390px minimum: hero text readable, CTA visible, focus states visible, no horizontal overflow.
  - Desktop `/asociaciones`: association cards should remain visually consistent and readable.

## Deployment note
- This branch is ready for the standard PR → merge → Cloudflare Pages deployment flow.
- I did not push to `main` directly.

## Safety / scope confirmation
- No Supabase changes.
- No pipeline changes.
- No AQI/provider changes.
- No geolocation changes.
- No data contract changes.
- No secrets or `service_role` added to frontend/app.
- No environmental data invented.
- No real-time monitoring claim added.
- No formal affiliation with associations or campaigns is claimed.