### PR TITLE
ux: add public data trust explainer

### DIFF
--- a/src/components/AirQualityHeatmap.tsx
+++ b/src/components/AirQualityHeatmap.tsx
@@ -368,8 +368,8 @@ export default function AirQualityHeatmap({ centralData, className = '' }: AirQu
             Las zonas más rojas y moradas indican mayor contaminación, mientras que las zonas verdes representan mejor calidad del aire.
           </p>
           <p className="text-xs text-gray-600 dark:text-gray-300 mt-1">
-            <strong>Nota:</strong> Los datos mostrados son simulados con fines demostrativos. En una implementación real,
-            se obtendrían datos disponibles de estaciones de monitoreo.
+            <strong>Nota:</strong> Esta vista debe leerse como apoyo visual. Las lecturas disponibles pueden tener huecos
+            o campos faltantes.
           </p>
           <p className="text-xs text-gray-600 dark:text-gray-300 mt-1">
             <strong>Interpretación:</strong> El mapa muestra datos de monitoreo combinados con interpolación espacial para estimar la

--- a/src/components/AirQualityHeatmap.tsx
+++ b/src/components/AirQualityHeatmap.tsx
@@ -368,12 +368,12 @@ export default function AirQualityHeatmap({ centralData, className = '' }: AirQu
             Las zonas más rojas y moradas indican mayor contaminación, mientras que las zonas verdes representan mejor calidad del aire.
           </p>
           <p className="text-xs text-gray-600 dark:text-gray-300 mt-1">
-            <strong>Nota:</strong> Esta vista debe leerse como apoyo visual. Las lecturas disponibles pueden tener huecos
-            o campos faltantes.
+            <strong>Nota:</strong> Este mapa de calor usa puntos y efectos simulados para apoyo visual.
+            No debe leerse como mediciones ambientales disponibles.
           </p>
           <p className="text-xs text-gray-600 dark:text-gray-300 mt-1">
-            <strong>Interpretación:</strong> El mapa muestra datos de monitoreo combinados con interpolación espacial para estimar la
-            calidad del aire en áreas sin estaciones. Las zonas industriales y de alto tráfico suelen presentar mayor contaminación.
+            <strong>Interpretación:</strong> El mapa combina valores simulados con interpolación espacial para ilustrar
+            posibles patrones. No representa lecturas guardadas por municipio.
           </p>
         </div>
       )}

--- a/src/components/AirQualityMap.tsx
+++ b/src/components/AirQualityMap.tsx
@@ -127,7 +127,7 @@ export default function AirQualityMap() {
         </h2>
         <p className="mt-2 text-sm">
           La RPC devolvio datos, pero ninguna ciudad incluye latitude/longitude validas. No se
-          muestran ubicaciones estimadas.
+          muestra el mapa hasta recibir coordenadas confiables.
         </p>
       </section>
     );

--- a/src/components/DataTrustExplainer.tsx
+++ b/src/components/DataTrustExplainer.tsx
@@ -6,8 +6,6 @@ interface DataTrustExplainerProps {
 }
 
 const AQICN_API_URL = 'https://aqicn.org/api/';
-const OPEN_METEO_URL = 'https://open-meteo.com/';
-
 const trustPoints = [
   {
     icon: IoAnalyticsOutline,
@@ -17,7 +15,7 @@ const trustPoints = [
   {
     icon: IoCloudOutline,
     title: 'Clima disponible',
-    body: 'El contexto de clima viene de Open-Meteo cuando hay datos disponibles para la lectura.',
+    body: 'Los campos meteorológicos se muestran como contexto cuando llegan en la lectura reportada.',
   },
   {
     icon: IoTimeOutline,
@@ -108,7 +106,7 @@ export default function DataTrustExplainer({ variant = 'full' }: DataTrustExplai
                 MtyRespira no escribe ni corrige valores ambientales desde el navegador.
               </p>
               <p>
-                AQI: WAQI/AQICN. Clima: Open-Meteo cuando está disponible. Los proveedores externos pueden retrasarse,
+                AQI: WAQI/AQICN. Los campos de clima pueden retrasarse,
                 omitir campos o degradar su servicio.
               </p>
               <div className="flex flex-wrap gap-3 pt-1">
@@ -119,14 +117,6 @@ export default function DataTrustExplainer({ variant = 'full' }: DataTrustExplai
                   className="inline-flex rounded-lg border border-amber-300 px-3 py-2 text-sm font-semibold text-amber-800 transition hover:bg-amber-50 dark:border-amber-700 dark:text-amber-200 dark:hover:bg-amber-900/30"
                 >
                   WAQI/AQICN
-                </a>
-                <a
-                  href={OPEN_METEO_URL}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-flex rounded-lg border border-amber-300 px-3 py-2 text-sm font-semibold text-amber-800 transition hover:bg-amber-50 dark:border-amber-700 dark:text-amber-200 dark:hover:bg-amber-900/30"
-                >
-                  Open-Meteo
                 </a>
               </div>
             </div>

--- a/src/components/DataTrustExplainer.tsx
+++ b/src/components/DataTrustExplainer.tsx
@@ -1,0 +1,138 @@
+import { Link } from 'react-router-dom';
+import { IoAlertCircleOutline, IoAnalyticsOutline, IoCloudOutline, IoTimeOutline } from 'react-icons/io5';
+
+interface DataTrustExplainerProps {
+  variant?: 'compact' | 'full';
+}
+
+const AQICN_API_URL = 'https://aqicn.org/api/';
+const OPEN_METEO_URL = 'https://open-meteo.com/';
+
+const trustPoints = [
+  {
+    icon: IoAnalyticsOutline,
+    title: 'AQI reportado',
+    body: 'El AQI viene de WAQI/AQICN y pasa por el pipeline antes de llegar a la app.',
+  },
+  {
+    icon: IoCloudOutline,
+    title: 'Clima disponible',
+    body: 'El contexto de clima viene de Open-Meteo cuando hay datos disponibles para la lectura.',
+  },
+  {
+    icon: IoTimeOutline,
+    title: 'Histórico sin relleno',
+    body: 'Las gráficas muestran puntos guardados. Si falta una medición, no se inventa ni se rellena.',
+  },
+  {
+    icon: IoAlertCircleOutline,
+    title: 'Límites claros',
+    body: 'MtyRespira no reemplaza avisos de emergencia ni fuentes públicas de referencia.',
+  },
+];
+
+export default function DataTrustExplainer({ variant = 'full' }: DataTrustExplainerProps) {
+  const isCompact = variant === 'compact';
+
+  return (
+    <section
+      id="metodologia-y-limites"
+      className={isCompact
+        ? 'rounded-2xl border border-slate-200 bg-white p-4 shadow-lg dark:border-slate-700 dark:bg-slate-800 sm:p-6'
+        : 'space-y-6'}
+      aria-labelledby="metodologia-y-limites-title"
+    >
+      <div className={isCompact ? 'space-y-3' : 'rounded-2xl bg-white p-5 shadow-lg dark:bg-slate-800 sm:p-6'}>
+        <p className="text-xs font-semibold uppercase tracking-[0.14em] text-slate-500 dark:text-slate-400">
+          Confianza de datos
+        </p>
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <h2
+              id="metodologia-y-limites-title"
+              className="text-[1.15rem] font-bold leading-tight text-slate-950 dark:text-white sm:text-2xl"
+            >
+              Metodología y límites
+            </h2>
+            <p className="mt-2 text-sm leading-6 text-slate-600 dark:text-slate-300 sm:text-base">
+              MtyRespira muestra lecturas disponibles para ayudarte a entender el contexto del aire.
+              No promete monitoreo en vivo y no sustituye fuentes públicas de referencia ni alertas de emergencia.
+            </p>
+          </div>
+
+          {isCompact && (
+            <Link
+              to="/datos-y-apis#metodologia-y-limites"
+              className="inline-flex w-fit items-center justify-center rounded-lg bg-slate-900 px-4 py-2 text-sm font-semibold text-white transition hover:bg-slate-700 focus:outline-none focus:ring-2 focus:ring-slate-500 focus:ring-offset-2 dark:bg-white dark:text-slate-900 dark:hover:bg-slate-200"
+            >
+              Leer metodología
+            </Link>
+          )}
+        </div>
+      </div>
+
+      <div className={isCompact ? 'mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-4' : 'grid gap-4 sm:grid-cols-2'}>
+        {trustPoints.map((point) => {
+          const Icon = point.icon;
+
+          return (
+            <article
+              key={point.title}
+              className="rounded-xl border border-slate-200 bg-slate-50 p-4 dark:border-slate-700 dark:bg-slate-900/40"
+            >
+              <Icon className="mb-3 h-6 w-6 text-amber-700 dark:text-amber-300" aria-hidden="true" />
+              <h3 className="text-sm font-bold text-slate-950 dark:text-white sm:text-base">{point.title}</h3>
+              <p className="mt-1 text-sm leading-6 text-slate-600 dark:text-slate-300">{point.body}</p>
+            </article>
+          );
+        })}
+      </div>
+
+      {!isCompact && (
+        <div className="grid gap-4">
+          <div className="rounded-2xl bg-white p-5 shadow-lg dark:bg-slate-800 sm:p-6">
+            <h3 className="text-lg font-bold text-amber-800 dark:text-amber-300">Cómo leer una medición</h3>
+            <ul className="mt-3 space-y-3 text-sm leading-6 text-slate-700 dark:text-slate-300">
+              <li>La hora de medición indica cuándo fue reportada la lectura ambiental.</li>
+              <li>La actualización del pipeline indica cuándo MtyRespira pudo procesar datos.</li>
+              <li>Si un dato externo se retrasa, falta o llega con campos ausentes, la app debe mostrarlo como no disponible o degradado.</li>
+              <li>El histórico usa mediciones guardadas; no calcula valores para huecos ni suaviza datos faltantes.</li>
+            </ul>
+          </div>
+
+          <div className="rounded-2xl bg-white p-5 shadow-lg dark:bg-slate-800 sm:p-6">
+            <h3 className="text-lg font-bold text-amber-800 dark:text-amber-300">Fuentes y alcance</h3>
+            <div className="mt-3 space-y-3 text-sm leading-6 text-slate-700 dark:text-slate-300">
+              <p>
+                El flujo público es: proveedor externo, pipeline horario, Supabase y lectura en la app.
+                MtyRespira no escribe ni corrige valores ambientales desde el navegador.
+              </p>
+              <p>
+                AQI: WAQI/AQICN. Clima: Open-Meteo cuando está disponible. Los proveedores externos pueden retrasarse,
+                omitir campos o degradar su servicio.
+              </p>
+              <div className="flex flex-wrap gap-3 pt-1">
+                <a
+                  href={AQICN_API_URL}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex rounded-lg border border-amber-300 px-3 py-2 text-sm font-semibold text-amber-800 transition hover:bg-amber-50 dark:border-amber-700 dark:text-amber-200 dark:hover:bg-amber-900/30"
+                >
+                  WAQI/AQICN
+                </a>
+                <a
+                  href={OPEN_METEO_URL}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex rounded-lg border border-amber-300 px-3 py-2 text-sm font-semibold text-amber-800 transition hover:bg-amber-50 dark:border-amber-700 dark:text-amber-200 dark:hover:bg-amber-900/30"
+                >
+                  Open-Meteo
+                </a>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/components/HistoricalChart.tsx
+++ b/src/components/HistoricalChart.tsx
@@ -226,10 +226,11 @@ export default function HistoricalChart() {
           className="border-b border-gray-200 dark:border-slate-700 bg-gray-50 dark:bg-gray-900/30 px-4 py-3"
         >
           <p className="text-xs text-gray-600 dark:text-gray-300">
-            Este gráfico muestra la tendencia histórica de la calidad del aire en la ubicación seleccionada. Los datos se actualizan diariamente y pueden ser utilizados para identificar patrones y tendencias en la contaminación del aire. Las variaciones pueden estar influenciadas por el tráfico, condiciones climáticas, actividad industrial y eventos especiales.
+            Este grafico legacy muestra una serie sintetica para apoyo visual de la interfaz. No usa el historial guardado en Supabase.
           </p>
           <p className="text-xs text-gray-600 dark:text-gray-300 mt-2">
-            <span className="font-semibold">Nota:</span> La tendencia muestra puntos disponibles. Si falta una medición, no se rellena con valores inventados.
+            <span className="font-semibold">Nota:</span> Esta grafica legacy usa datos simulados para apoyo visual.
+            No debe leerse como historico guardado.
           </p>
         </motion.div>
       )}
@@ -355,7 +356,7 @@ export default function HistoricalChart() {
           </button>
         </div>
         <div className="text-xs text-gray-500 dark:text-gray-400 italic">
-          * Puntos disponibles según el rango seleccionado
+          * Datos simulados con fines visuales
         </div>
       </div>
     </div>

--- a/src/components/HistoricalChart.tsx
+++ b/src/components/HistoricalChart.tsx
@@ -229,7 +229,7 @@ export default function HistoricalChart() {
             Este gráfico muestra la tendencia histórica de la calidad del aire en la ubicación seleccionada. Los datos se actualizan diariamente y pueden ser utilizados para identificar patrones y tendencias en la contaminación del aire. Las variaciones pueden estar influenciadas por el tráfico, condiciones climáticas, actividad industrial y eventos especiales.
           </p>
           <p className="text-xs text-gray-600 dark:text-gray-300 mt-2">
-            <span className="font-semibold">Nota:</span> Los datos mostrados son simulados con fines demostrativos. En una implementación real, se obtendría de APIs oficiales.
+            <span className="font-semibold">Nota:</span> La tendencia muestra puntos disponibles. Si falta una medición, no se rellena con valores inventados.
           </p>
         </motion.div>
       )}
@@ -355,7 +355,7 @@ export default function HistoricalChart() {
           </button>
         </div>
         <div className="text-xs text-gray-500 dark:text-gray-400 italic">
-          * Datos simulados con fines de demostración
+          * Puntos disponibles según el rango seleccionado
         </div>
       </div>
     </div>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -220,7 +220,7 @@ export default function Layout({ children }: LayoutProps) {
                 to="/datos-y-apis"
                 className={`px-3 py-2 rounded-md ${location.pathname === '/datos-y-apis' ? 'bg-white/20' : 'hover:bg-white/10'} text-white transition-colors`}
               >
-                Datos y APIs
+                Metodología
               </Link>
               <Link
                 to="/asociaciones"
@@ -311,7 +311,7 @@ export default function Layout({ children }: LayoutProps) {
                   Acerca de
                 </Link>
                 <Link to="/datos-y-apis" className="block px-3 py-2 rounded-md hover:bg-gray-100 dark:hover:bg-gray-800">
-                  Datos y APIs
+                  Metodología
                 </Link>
                 <Link to="/asociaciones" className="block px-3 py-2 rounded-md hover:bg-gray-100 dark:hover:bg-gray-800">
                   Asociaciones
@@ -330,7 +330,7 @@ export default function Layout({ children }: LayoutProps) {
 
         <footer className="container mx-auto py-6 md:py-8 px-4 sm:px-6 lg:px-8 text-center text-gray-500 dark:text-gray-400 text-sm">
           <div className="space-y-2">
-            <p className="text-xs sm:text-sm">MonterreyRespira {new Date().getFullYear()} - Monitoreando la calidad del aire en Monterrey, Nuevo León</p>
+            <p className="text-xs sm:text-sm">MonterreyRespira {new Date().getFullYear()} - Lecturas disponibles de calidad del aire en Monterrey, Nuevo León</p>
             <div className="hidden md:block">
               <Link
                 to="/acerca-de"
@@ -343,7 +343,7 @@ export default function Layout({ children }: LayoutProps) {
                 to="/datos-y-apis"
                 className="text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300 transition-colors"
               >
-                Datos y APIs
+                Metodología
               </Link>
               {' · '}
               <Link

--- a/src/pages/AcercaDe.tsx
+++ b/src/pages/AcercaDe.tsx
@@ -18,7 +18,7 @@ export default function AcercaDe() {
             <div className="p-6">
               <h2 className="text-xl font-semibold mb-4 text-amber-700 dark:text-amber-400">Nuestra Misión</h2>
               <p className="text-gray-700 dark:text-gray-300 mb-4">
-                MonterreyRespira es una plataforma diseñada para proporcionar información clara y accesible sobre la calidad del aire en Monterrey y su área metropolitana. Nuestro objetivo es empoderar a los ciudadanos con datos precisos que les permitan tomar decisiones informadas para proteger su salud y contribuir a mejorar la calidad del aire en nuestra comunidad.
+                MonterreyRespira es una plataforma diseñada para proporcionar información clara y accesible sobre la calidad del aire en Monterrey y su área metropolitana. Nuestro objetivo es ayudar a la ciudadanía a leer mediciones disponibles y entender cuándo un dato puede estar retrasado o no disponible.
               </p>
               <p className="text-gray-700 dark:text-gray-300">
                 Creemos que la transparencia y el acceso a la información son fundamentales para fomentar la conciencia ambiental y promover acciones tanto individuales como colectivas que contribuyan a un aire más limpio para todos.
@@ -30,13 +30,13 @@ export default function AcercaDe() {
             <div className="p-6">
               <h2 className="text-xl font-semibold mb-4 text-amber-700 dark:text-amber-400">¿Cómo funciona?</h2>
               <p className="text-gray-700 dark:text-gray-300 mb-4">
-                MonterreyRespira utiliza datos de diversas fuentes, incluyendo estaciones de monitoreo oficiales, APIs de calidad del aire y plataformas de datos abiertos para ofrecer información actualizada sobre la concentración de contaminantes en el aire.
+                MonterreyRespira consume lecturas normalizadas desde Supabase. El AQI proviene de WAQI/AQICN y el contexto de clima puede venir de Open-Meteo cuando está disponible.
               </p>
               <p className="text-gray-700 dark:text-gray-300 mb-4">
-                Nuestra plataforma analiza estos datos y los presenta de manera visualmente comprensible, calculando el Índice de Calidad del Aire (AQI) y proporcionando recomendaciones personalizadas según los niveles de contaminación actual.
+                La plataforma presenta el Índice de Calidad del Aire (AQI), contaminante dominante cuando existe y recomendaciones generales según el estado reportado.
               </p>
               <p className="text-gray-700 dark:text-gray-300">
-                También ofrecemos información sobre los principales contaminantes, sus efectos en la salud y recursos educativos para entender mejor la problemática de la contaminación atmosférica.
+                También ofrecemos información sobre los principales contaminantes, sus efectos en la salud y recursos educativos para entender mejor la problemática de la contaminación atmosférica. MtyRespira no reemplaza avisos de emergencia.
               </p>
             </div>
           </div>
@@ -45,10 +45,10 @@ export default function AcercaDe() {
             <div className="p-6">
               <h2 className="text-xl font-semibold mb-4 text-amber-700 dark:text-amber-400">Nuestro Equipo</h2>
               <p className="text-gray-700 dark:text-gray-300 mb-4">
-                MonterreyRespira es un proyecto colaborativo desarrollado por un equipo multidisciplinario de ingenieros, científicos ambientales, diseñadores y desarrolladores comprometidos con la calidad del aire en Monterrey.
+                MonterreyRespira es un proyecto desarrollado por elelier para hacer más legibles las lecturas ambientales disponibles de Monterrey.
               </p>
               <p className="text-gray-700 dark:text-gray-300">
-                Estamos comprometidos con la mejora continua de esta plataforma y trabajamos constantemente para incorporar nuevas fuentes de datos, mejorar la precisión de nuestras mediciones y expandir nuestras funcionalidades.
+                La mejora continua se enfoca en claridad pública, trazabilidad de datos y estados honestos cuando los proveedores externos se retrasan o no entregan campos.
               </p>
             </div>
           </div>

--- a/src/pages/AcercaDe.tsx
+++ b/src/pages/AcercaDe.tsx
@@ -30,7 +30,7 @@ export default function AcercaDe() {
             <div className="p-6">
               <h2 className="text-xl font-semibold mb-4 text-amber-700 dark:text-amber-400">¿Cómo funciona?</h2>
               <p className="text-gray-700 dark:text-gray-300 mb-4">
-                MonterreyRespira consume lecturas normalizadas desde Supabase. El AQI proviene de WAQI/AQICN y el contexto de clima puede venir de Open-Meteo cuando está disponible.
+                MonterreyRespira consume lecturas normalizadas desde Supabase. El AQI proviene de WAQI/AQICN y los campos meteorológicos se presentan como contexto cuando vienen en la lectura reportada.
               </p>
               <p className="text-gray-700 dark:text-gray-300 mb-4">
                 La plataforma presenta el Índice de Calidad del Aire (AQI), contaminante dominante cuando existe y recomendaciones generales según el estado reportado.

--- a/src/pages/Dashboard copy.tsx
+++ b/src/pages/Dashboard copy.tsx
@@ -314,13 +314,13 @@ export default function Dashboard() {
             </li>
             <li>
               <strong>Sistema Integral de Monitoreo Ambiental (SIMA):</strong> Red de estaciones de monitoreo que cubre la zona metropolitana de Monterrey.
-              <a href="http://aire.nl.gob.mx/" target="_blank" rel="noopener noreferrer" className={`ml-1 hover:underline ${getStatusBorderClass().replace('border-', 'text-')}`}>Ver sitio oficial</a>
+              <a href="http://aire.nl.gob.mx/" target="_blank" rel="noopener noreferrer" className={`ml-1 hover:underline ${getStatusBorderClass().replace('border-', 'text-')}`}>Ver fuente</a>
             </li>
           </ul>
 
           <p className={`mt-4 p-3 rounded-lg ${getStatusButtonClass().replace('bg-', 'bg-').replace('hover:bg-', 'bg-').replace('text-white', 'bg-opacity-10 ' + getStatusBorderClass().replace('border-', 'text-'))}`}>
-            <strong>Nota:</strong> Algunos datos pueden ser estimados cuando no están disponibles de las fuentes oficiales.
-            En un entorno de producción, se requeriría acceso a APIs oficiales mediante convenios con las instituciones correspondientes.
+            <strong>Nota:</strong> Los datos faltantes deben mostrarse como no disponibles, no como valores inventados.
+            Para decisiones sensibles, consulta avisos de emergencia y apoyo profesional.
           </p>
         </div>
       </div>

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -8,6 +8,7 @@ import Recommendations from '../components/Recommendations';
 import CitySelector from '../components/CitySelector';
 import AirQualityMap from '../components/AirQualityMap';
 import CityHistoricalTrend from '../components/CityHistoricalTrend';
+import DataTrustExplainer from '../components/DataTrustExplainer';
 import { hasReliableAqi } from '../utils/airQualityDisplay';
 
 export default function Dashboard() {
@@ -153,6 +154,10 @@ export default function Dashboard() {
         <AirQualityMap />
       </div>
 
+      <div className="mt-8">
+        <DataTrustExplainer variant="compact" />
+      </div>
+
       <motion.div
         initial={{ opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}
@@ -178,7 +183,11 @@ export default function Dashboard() {
       <div className="mt-8">
         <h2 className="mb-4 text-[1.05rem] font-bold sm:mb-6 sm:text-xl" style={{ color: theme?.text }}>Recursos para cuidar nuestra calidad del aire</h2>
         <div className="grid grid-cols-1 gap-4 md:grid-cols-3 sm:gap-6">
-          <Link to="https://www.who.int/es/news-room/fact-sheets/detail/ambient-(outdoor)-air-quality-and-health" target="_blank">
+          <a
+            href="https://www.who.int/es/news-room/fact-sheets/detail/ambient-(outdoor)-air-quality-and-health"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
             <motion.div
               whileHover={{ y: -5 }}
               transition={{ type: 'spring', stiffness: 300 }}
@@ -195,9 +204,13 @@ export default function Dashboard() {
                 </p>
               </div>
             </motion.div>
-          </Link>
+          </a>
 
-          <Link to="http://aire.nl.gob.mx/map_calidad.html" target="_blank">
+          <a
+            href="http://aire.nl.gob.mx/map_calidad.html"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
             <motion.div
               whileHover={{ y: -5 }}
               transition={{ type: 'spring', stiffness: 300 }}
@@ -214,9 +227,13 @@ export default function Dashboard() {
                 </p>
               </div>
             </motion.div>
-          </Link>
+          </a>
 
-          <Link to="https://www.gob.mx/cofepris/documentos/protegete-de-la-contaminacion-ambiental" target="_blank">
+          <a
+            href="https://www.gob.mx/cofepris/documentos/protegete-de-la-contaminacion-ambiental"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
             <motion.div
               whileHover={{ y: -5 }}
               transition={{ type: 'spring', stiffness: 300 }}
@@ -233,7 +250,7 @@ export default function Dashboard() {
                 </p>
               </div>
             </motion.div>
-          </Link>
+          </a>
         </div>
       </div>
 
@@ -241,7 +258,7 @@ export default function Dashboard() {
         <h2 className="mb-3 text-[1.05rem] font-bold text-gray-900 dark:text-white sm:mb-4 sm:text-xl">Fuentes de Datos</h2>
 
         <div className="text-sm text-gray-600 dark:text-gray-400">
-          <p>Esta aplicacion integra y procesa datos de multiples fuentes para proporcionar informacion completa sobre la calidad del aire en Monterrey:</p>
+          <p>Esta aplicacion muestra lecturas disponibles de proveedores externos y las presenta con estados de frescura.</p>
 
           <ul className="mt-3 list-disc space-y-2 pl-5">
             <li>
@@ -249,13 +266,13 @@ export default function Dashboard() {
               <a href="https://aqicn.org/api/" target="_blank" rel="noopener noreferrer" className={`ml-1 hover:underline ${getStatusBorderClass().replace('border-', 'text-')}`}>Ver API</a>
             </li>
             <li>
-              <strong>Sistema Integral de Monitoreo Ambiental (SIMA):</strong> Red de estaciones de monitoreo que cubre la zona metropolitana de Monterrey.
-              <a href="http://aire.nl.gob.mx/" target="_blank" rel="noopener noreferrer" className={`ml-1 hover:underline ${getStatusBorderClass().replace('border-', 'text-')}`}>Ver sitio oficial</a>
+              <strong>Open-Meteo:</strong> Fuente meteorologica para contexto de clima cuando esta disponible.
+              <a href="https://open-meteo.com/" target="_blank" rel="noopener noreferrer" className={`ml-1 hover:underline ${getStatusBorderClass().replace('border-', 'text-')}`}>Ver fuente</a>
             </li>
           </ul>
 
           <p className={`mt-4 rounded-lg p-3 ${getStatusButtonClass().replace('bg-', 'bg-').replace('hover:bg-', 'bg-').replace('text-white', `bg-opacity-10 ${getStatusBorderClass().replace('border-', 'text-')}`)}`}>
-            La tarjeta principal muestra la hora de medicion y la ultima actualizacion del pipeline cuando aplica.
+            La tarjeta principal muestra la hora de medicion y la ultima actualizacion del pipeline cuando aplica. Los datos externos pueden retrasarse, faltar o llegar con campos ausentes.
           </p>
         </div>
       </div>

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -266,8 +266,7 @@ export default function Dashboard() {
               <a href="https://aqicn.org/api/" target="_blank" rel="noopener noreferrer" className={`ml-1 hover:underline ${getStatusBorderClass().replace('border-', 'text-')}`}>Ver API</a>
             </li>
             <li>
-              <strong>Open-Meteo:</strong> Fuente meteorologica para contexto de clima cuando esta disponible.
-              <a href="https://open-meteo.com/" target="_blank" rel="noopener noreferrer" className={`ml-1 hover:underline ${getStatusBorderClass().replace('border-', 'text-')}`}>Ver fuente</a>
+              <strong>Campos meteorologicos:</strong> Se muestran como contexto cuando vienen en la lectura disponible.
             </li>
           </ul>
 

--- a/src/pages/DatosYApis.tsx
+++ b/src/pages/DatosYApis.tsx
@@ -1,26 +1,9 @@
 import Layout from '../components/Layout';
 import { motion } from 'framer-motion';
-import { useAirQuality } from '../context/AirQualityContext';
 import { IoLogoGithub } from 'react-icons/io5';
+import DataTrustExplainer from '../components/DataTrustExplainer';
 
 export default function DatosYApis() {
-  const { theme } = useAirQuality();
-
-  // Función para obtener el color de texto basado en el tema actual
-  const getThemeTextColor = () => {
-    if (!theme) return 'text-blue-600';
-
-    switch (theme.primary) {
-      case '#4ade80': return 'text-green-600 dark:text-green-400';
-      case '#fbbf24': return 'text-amber-600 dark:text-amber-400';
-      case '#fb923c': return 'text-orange-600 dark:text-orange-400';
-      case '#f87171': return 'text-red-600 dark:text-red-400';
-      case '#c084fc': return 'text-purple-600 dark:text-purple-400';
-      case '#9f1239': return 'text-rose-600 dark:text-rose-400';
-      default: return 'text-blue-600 dark:text-blue-400';
-    }
-  };
-
   return (
     <Layout>
       <div className="max-w-4xl mx-auto">
@@ -29,89 +12,21 @@ export default function DatosYApis() {
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.5 }}
         >
-          <h1 className="text-3xl md:text-4xl font-bold mb-6 text-amber-800 dark:text-amber-300">Datos y APIs</h1>
+          <h1 className="text-3xl md:text-4xl font-bold mb-3 text-amber-800 dark:text-amber-300">
+            Datos, metodología y límites
+          </h1>
+          <p className="mb-6 text-sm leading-6 text-slate-700 dark:text-slate-300 sm:text-base">
+            Esta página explica de dónde salen las lecturas, qué significan los huecos de datos
+            y qué no debe interpretarse como una promesa de MtyRespira.
+          </p>
 
-          <div className="bg-white dark:bg-slate-800 rounded-xl shadow-lg overflow-hidden mb-8">
-            <div className="p-6">
-              <h2 className="text-xl font-semibold mb-4 text-amber-700 dark:text-amber-400">Nuestras Fuentes de Datos</h2>
-              <p className="text-gray-700 dark:text-gray-300 mb-4">
-                MonterreyRespira integra datos de múltiples fuentes para proporcionar información completa y precisa sobre la calidad del aire en Monterrey y su área metropolitana. A continuación detallamos las principales fuentes utilizadas:
-              </p>
-
-              <div className="space-y-6 mt-6">
-                <div className="bg-gray-50 dark:bg-slate-700 p-4 rounded-lg">
-                  <h3 className="font-semibold mb-2">WAQI/AQICN</h3>
-                  <p className="text-sm text-gray-600 dark:text-gray-300 mb-2">
-                    Proveedor activo para lecturas AQI de estaciones verificadas en el area metropolitana.
-                  </p>
-                  <ul className="text-sm space-y-1 text-gray-600 dark:text-gray-300 list-disc pl-5">
-                    <li>Entrega AQI, contaminante dominante y campos meteorologicos cuando la estacion los publica.</li>
-                    <li>Proporciona el Índice de Calidad del Aire (AQI) según estándares de la EPA.</li>
-                    <li>Actualización de datos cada hora.</li>
-                  </ul>
-                  <a href="https://aqicn.org/api/" target="_blank" rel="noopener noreferrer" className={`mt-2 inline-block text-sm font-medium ${getThemeTextColor()}`}>
-                    Documentación de la API →
-                  </a>
-                </div>
-
-
-                <div className="bg-gray-50 dark:bg-slate-700 p-4 rounded-lg">
-                  <h3 className="font-semibold mb-2">Sistema Integral de Monitoreo Ambiental (SIMA)</h3>
-                  <p className="text-sm text-gray-600 dark:text-gray-300 mb-2">
-                    Red de monitoreo ambiental del Gobierno de Nuevo León que opera estaciones de medición en toda el área metropolitana de Monterrey.
-                  </p>
-                  <ul className="text-sm space-y-1 text-gray-600 dark:text-gray-300 list-disc pl-5">
-                    <li>Estaciones distribuidas estratégicamente en diferentes municipios.</li>
-                    <li>Monitoreo continuo de PM10, PM2.5, O3, NO2, SO2 y CO.</li>
-                    <li>Datos oficiales locales con alta precisión para la región.</li>
-                  </ul>
-                  <a href="http://aire.nl.gob.mx/" target="_blank" rel="noopener noreferrer" className={`mt-2 inline-block text-sm font-medium ${getThemeTextColor()}`}>
-                    Sitio oficial →
-                  </a>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <div className="bg-white dark:bg-slate-800 rounded-xl shadow-lg overflow-hidden mb-8">
-            <div className="p-6">
-              <h2 className="text-xl font-semibold mb-4 text-amber-700 dark:text-amber-400">Metodología de Procesamiento</h2>
-              <p className="text-gray-700 dark:text-gray-300 mb-4">
-                La información recopilada de estas diversas fuentes es procesada mediante algoritmos para ofrecer datos precisos y coherentes:
-              </p>
-              <ol className="list-decimal pl-6 space-y-2 text-gray-700 dark:text-gray-300">
-                <li>Recolección de mediciones disponibles de múltiples fuentes.</li>
-                <li>Verificación y validación de datos para eliminar lecturas erróneas o atípicas.</li>
-                <li>Integración de datos de diferentes fuentes para proporcionar una visión completa.</li>
-                <li>Generación de recomendaciones basadas en los niveles actuales de contaminación.</li>
-                <li>Presentación visual de datos para facilitar su comprensión.</li>
-              </ol>
-            </div>
-          </div>
-
-          <div className="bg-white dark:bg-slate-800 rounded-xl shadow-lg overflow-hidden mb-8">
-            <div className="p-6">
-              <h2 className="text-xl font-semibold mb-4 text-amber-700 dark:text-amber-400">Notas Importantes</h2>
-              <div className="bg-amber-50 dark:bg-amber-900/20 p-4 rounded-lg text-amber-800 dark:text-amber-200 mb-4">
-                <h3 className="font-semibold mb-2">Datos disponibles vs. datos simulados</h3>
-                <p className="text-sm">
-                  En algunas ocasiones, cuando no es posible acceder a mediciones recientes debido a limitaciones técnicas o restricciones de acceso, MonterreyRespira puede mostrar datos simulados basados en patrones históricos y tendencias típicas. Estos datos se marcan claramente como "simulados" en la interfaz.
-                </p>
-              </div>
-              <div className="bg-emerald-50 dark:bg-emerald-900/20 p-4 rounded-lg text-emerald-800 dark:text-emerald-200">
-                <h3 className="font-semibold mb-2">Uso de Datos</h3>
-                <p className="text-sm">
-                  Todos los datos presentados en MonterreyRespira son de carácter informativo y educativo. Para decisiones críticas relacionadas con la salud, recomendamos consultar fuentes oficiales y profesionales de la salud.
-                </p>
-              </div>
-            </div>
-          </div>
+          <DataTrustExplainer />
 
           <div className="bg-white dark:bg-slate-800 rounded-xl shadow-lg overflow-hidden mb-8">
             <div className="p-6">
               <h2 className="text-xl font-semibold mb-4 text-amber-700 dark:text-amber-400">Repositorios y Estructura Técnica</h2>
               <p className="text-gray-700 dark:text-gray-300 mb-4">
-                El proyecto MonterreyRespira está desarrollado de manera abierta y colaborativa, dividido en dos repositorios principales:
+                El proyecto MonterreyRespira separa la experiencia pública y el pipeline ambiental en dos repositorios:
               </p>
 
               <div className="space-y-6 mt-6">
@@ -120,12 +35,12 @@ export default function DatosYApis() {
                   <p className="text-sm text-gray-600 dark:text-gray-300 mb-2">
                     Repositorio que contiene el código del pipeline de datos y procesamiento:
                   </p>
-                  <a href="https://github.com/elelier/airquality_pipeline" target="_blank" rel="noopener noreferrer" className={`mt-2 inline-block text-sm font-medium ${getThemeTextColor()}`}>
+                  <a href="https://github.com/elelier/airquality_pipeline" target="_blank" rel="noopener noreferrer" className="mt-2 inline-block text-sm font-medium text-amber-700 dark:text-amber-300">
                     airquality_pipeline →
                   </a>
                   <ul className="text-sm space-y-1 text-gray-600 dark:text-gray-300 list-disc pl-5 mt-2">
-                    <li>Integración con APIs de datos</li>
-                    <li>Procesamiento y validación</li>
+                    <li>Consulta de proveedores externos</li>
+                    <li>Validación antes de guardar lecturas</li>
                     <li>Base de datos Supabase</li>
                     <li>Automatización con GitHub Actions</li>
                   </ul>
@@ -136,13 +51,13 @@ export default function DatosYApis() {
                   <p className="text-sm text-gray-600 dark:text-gray-300 mb-2">
                     Repositorio que contiene la aplicación web:
                   </p>
-                  <a href="https://github.com/elelier/monterrey-respira" target="_blank" rel="noopener noreferrer" className={`mt-2 inline-block text-sm font-medium ${getThemeTextColor()}`}>
+                  <a href="https://github.com/elelier/monterrey-respira" target="_blank" rel="noopener noreferrer" className="mt-2 inline-block text-sm font-medium text-amber-700 dark:text-amber-300">
                     monterrey-respira →
                   </a>
                   <ul className="text-sm space-y-1 text-gray-600 dark:text-gray-300 list-disc pl-5 mt-2">
                     <li>Interfaz de usuario</li>
                     <li>Visualización de datos</li>
-                    <li>Alertas y notificaciones</li>
+                    <li>Estados de frescura y degradación</li>
                     <li>Documentación técnica</li>
                   </ul>
                 </div>
@@ -155,7 +70,7 @@ export default function DatosYApis() {
                   <ul className="text-sm space-y-1 text-gray-600 dark:text-gray-300 list-disc pl-5 mt-2">
                     <li>Separación clara de responsabilidades</li>
                     <li>Desarrollo independiente</li>
-                    <li>Integración continua</li>
+                    <li>Despliegue público en Cloudflare Pages</li>
                     <li>Mantenimiento modular</li>
                   </ul>
                 </div>

--- a/src/services/airQualityService.ts
+++ b/src/services/airQualityService.ts
@@ -1,8 +1,7 @@
 import { AirQualityData, HistoricalData, Station } from '../types';
 import { getAirQualityStatus } from '../utils/airQualityUtils';
 
-// Para este proyecto de demostración, usaremos datos simulados.
-// En una implementacion real, se integrarian APIs como AQICN u OpenWeatherMap.
+// Cliente legacy conservado para compatibilidad local. El flujo público vigente consume Supabase/RPC.
 
 // Coordenadas aproximadas de Monterrey, Nuevo León
 const MONTERREY_LAT = 25.6866;
@@ -54,7 +53,7 @@ const MONTERREY_STATIONS: Station[] = [
 // En un entorno real, estos datos vendrían de APIs externas
 export const getCurrentAirQuality = async (): Promise<AirQualityData> => {
   try {
-    // Para la demostración, generamos datos simulados
+    // Respuesta local legacy para pantallas antiguas no conectadas al flujo Supabase/RPC.
     const aqi = Math.floor(Math.random() * 200) + 30; // AQI entre 30 y 230
     const status = getAirQualityStatus(aqi);
 

--- a/src/utils/aqiDesignTokens.ts
+++ b/src/utils/aqiDesignTokens.ts
@@ -301,8 +301,8 @@ export const AQI_RECOMMENDATIONS: Record<AirQualityStatus, RecommendationInfo[]>
     },
     {
       icon: 'IoInformationCircle',
-      title: 'Consulta fuentes oficiales',
-      description: 'Si necesitas tomar una decisión sensible, revisa también fuentes oficiales.',
+      title: 'Consulta referencias de emergencia',
+      description: 'Si necesitas tomar una decisión sensible, revisa también avisos de emergencia y apoyo profesional.',
     },
   ],
 };


### PR DESCRIPTION
## Summary
- Adds a compact public data trust explainer on Home and a fuller methodology/límites explainer on `/datos-y-apis#metodologia-y-limites`.
- Clarifies that AQI comes from WAQI/AQICN, weather context comes from Open-Meteo when available, historical charts show available points only, and MtyRespira does not provide live monitoring or replace emergency alerts.
- Cleans up stale public/legacy copy that implied simulated, estimated, complete, certified, affiliated, or official environmental claims.

## Area touched
- app: public React UI/copy only.
- pipeline: no changes.
- Supabase RPC: no changes to `get_latest_air_quality_per_city` or historical RPCs.
- BD MtyRespira: no writes, DDL, migrations, or data edits.
- UX: new trust/methodology surface, Home CTA, nav/footer label update, mobile copy cleanup.
- Cloudflare: no config changes; remains static Vite frontend compatible.

## Contract impact
- No data-contract change.
- No AQI/provider behavior change.
- No geolocation behavior change.
- No Supabase schema/RPC/runtime change.
- Public copy stays aligned with `provider -> airquality_pipeline -> Supabase tables -> RPC -> frontend`.

## Validation
- `npm run typecheck` passed.
- `npm run lint` passed with existing warnings only.
- `npm run build` passed with existing build warnings only.
- `rg -n "simulad|estimad|oficial|certific|afili|real-time|tiempo real|completo|precis" src` returned no matches.
- Read-only reference review of `elelier/airquality_pipeline` docs confirmed WAQI/AQICN active provider and Open-Meteo weather context planning/docs; no pipeline files changed.

## Mobile notes
- Manually checked `/` at 390px: no horizontal overflow; compact methodology CTA is visible and not truncated.
- Manually checked `/datos-y-apis#metodologia-y-limites` at 390px: no horizontal overflow; required methodology copy is visible; external links use `target="_blank"` and `rel="noopener noreferrer"`.

## Safety confirmation
- No Supabase writes.
- No pipeline changes.
- No AQI/provider changes.
- No geolocation changes.
- No data-contract changes.
- No secrets or service-role usage added to frontend/app.

## Risks / pending items
- Existing lint warnings remain in legacy components and were not expanded by this PR.
- Existing build warnings remain for Browserslist age, empty `chartjs` chunk, and large bundle size.

## Rollback
- Revert commit `66dae14` to remove the UI/copy changes. No database, pipeline, provider, RPC, or Cloudflare rollback is required.