### PR TITLE
ux: harden public source methodology

### DIFF
--- a/docs/freshness-truth-ux.md
+++ b/docs/freshness-truth-ux.md
@@ -1,6 +1,6 @@
 # Freshness Truth UX
 
-Status: Story 1.2 frontend note
+Status: Story 1.2 frontend note; public methodology hardening updated by Story UX-Trust-Next.
 
 Scope: `monterrey-respira` frontend only. No Supabase schema changes, no RPC changes, no pipeline runtime changes, no provider changes, and no service role in the app.
 
@@ -8,6 +8,7 @@ Scope: `monterrey-respira` frontend only. No Supabase schema changes, no RPC cha
 
 - `reading_timestamp` is the environmental measurement time. It drives the dashboard freshness status.
 - `last_successful_update_at` is pipeline success traceability. It may be shown as `Pipeline ...`, but it is not measurement freshness.
+- `weather_timestamp` is weather context measurement time when canonical weather fields are available.
 - Frontend cache or refresh time only means the app fetched or read data. It must not be described as a new measurement.
 
 ## Latest-reading thresholds
@@ -35,3 +36,14 @@ The AQI card should distinguish:
 - `Pipeline ...` from `last_successful_update_at`.
 
 Do not use stronger freshness language than the hourly producer cadence can support.
+
+## Public source and methodology surface
+
+Public copy may expose a compact and full methodology surface, but it must stay aligned with the shared data contract:
+
+- AQI source: WAQI/AQICN through the pipeline and Supabase/RPC.
+- Weather context: Open-Meteo when canonical `weather_*` fields are available; this is secondary context and must not be described as the AQI source.
+- Attribution: WAQI/AQICN and the EPA/source originator must be visible where source methodology is explained.
+- Degraded states: `Medicion con retraso`, `Dato viejo`, and `Sin lectura disponible` must be explained in user-facing language.
+- CTAs should route to existing product surfaces only. Do not add a public problem/suggestion submission CTA until there is a specific Core DB `submit_signal` integration for that signal kind.
+- Core DB remains limited to product signals and is not a source of AQI, weather, historical readings, or provider state.

--- a/src/components/DataTrustExplainer.tsx
+++ b/src/components/DataTrustExplainer.tsx
@@ -1,32 +1,46 @@
 import { Link } from 'react-router-dom';
-import { IoAlertCircleOutline, IoAnalyticsOutline, IoCloudOutline, IoTimeOutline } from 'react-icons/io5';
+import {
+  IoAlertCircleOutline,
+  IoAnalyticsOutline,
+  IoCloudOutline,
+  IoReaderOutline,
+  IoTimeOutline,
+} from 'react-icons/io5';
 
 interface DataTrustExplainerProps {
   variant?: 'compact' | 'full';
 }
 
 const AQICN_API_URL = 'https://aqicn.org/api/';
+const OPEN_METEO_URL = 'https://open-meteo.com/';
+
 const trustPoints = [
   {
     icon: IoAnalyticsOutline,
     title: 'AQI reportado',
-    body: 'El AQI viene de WAQI/AQICN y pasa por el pipeline antes de llegar a la app.',
+    body: 'El AQI viene de WAQI/AQICN, pasa por el pipeline horario y se muestra como lectura disponible.',
   },
   {
     icon: IoCloudOutline,
-    title: 'Clima disponible',
-    body: 'Los campos meteorológicos se muestran como contexto cuando llegan en la lectura reportada.',
+    title: 'Clima de contexto',
+    body: 'Cuando la UI muestra clima, puede venir de Open-Meteo como fuente secundaria; no cambia el AQI.',
   },
   {
     icon: IoTimeOutline,
-    title: 'Histórico sin relleno',
-    body: 'Las gráficas muestran puntos guardados. Si falta una medición, no se inventa ni se rellena.',
+    title: 'Medición vs actualización',
+    body: 'La medición usa reading_timestamp; la actualización del pipeline usa last_successful_update_at.',
   },
   {
     icon: IoAlertCircleOutline,
-    title: 'Límites claros',
-    body: 'MtyRespira no reemplaza avisos de emergencia ni fuentes públicas de referencia.',
+    title: 'Degradación visible',
+    body: 'Con retraso, vieja o sin lectura explica datos demorados, antiguos o no confiables.',
   },
+];
+
+const internalLinks = [
+  { label: 'Ver datos', to: '/#datos' },
+  { label: 'Entender AQI', to: '/datos-y-apis#como-leer-aqi' },
+  { label: 'Fuentes y límites', to: '/datos-y-apis#metodologia-y-limites' },
 ];
 
 export default function DataTrustExplainer({ variant = 'full' }: DataTrustExplainerProps) {
@@ -42,7 +56,7 @@ export default function DataTrustExplainer({ variant = 'full' }: DataTrustExplai
     >
       <div className={isCompact ? 'space-y-3' : 'rounded-2xl bg-white p-5 shadow-lg dark:bg-slate-800 sm:p-6'}>
         <p className="text-xs font-semibold uppercase tracking-[0.14em] text-slate-500 dark:text-slate-400">
-          Confianza de datos
+          Fuentes y metodología
         </p>
         <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
           <div>
@@ -50,7 +64,7 @@ export default function DataTrustExplainer({ variant = 'full' }: DataTrustExplai
               id="metodologia-y-limites-title"
               className="text-[1.15rem] font-bold leading-tight text-slate-950 dark:text-white sm:text-2xl"
             >
-              Metodología y límites
+              Cómo leer MtyRespira sin promesas excesivas
             </h2>
             <p className="mt-2 text-sm leading-6 text-slate-600 dark:text-slate-300 sm:text-base">
               MtyRespira muestra lecturas disponibles para ayudarte a entender el contexto del aire.
@@ -67,6 +81,20 @@ export default function DataTrustExplainer({ variant = 'full' }: DataTrustExplai
             </Link>
           )}
         </div>
+
+        {!isCompact && (
+          <div className="mt-5 flex flex-wrap gap-3">
+            {internalLinks.map((link) => (
+              <Link
+                key={link.to}
+                to={link.to}
+                className="inline-flex rounded-lg border border-amber-300 px-3 py-2 text-sm font-semibold text-amber-800 transition hover:bg-amber-50 focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-2 dark:border-amber-700 dark:text-amber-200 dark:hover:bg-amber-900/30"
+              >
+                {link.label}
+              </Link>
+            ))}
+          </div>
+        )}
       </div>
 
       <div className={isCompact ? 'mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-4' : 'grid gap-4 sm:grid-cols-2'}>
@@ -88,35 +116,58 @@ export default function DataTrustExplainer({ variant = 'full' }: DataTrustExplai
 
       {!isCompact && (
         <div className="grid gap-4">
-          <div className="rounded-2xl bg-white p-5 shadow-lg dark:bg-slate-800 sm:p-6">
-            <h3 className="text-lg font-bold text-amber-800 dark:text-amber-300">Cómo leer una medición</h3>
+          <div id="como-leer-aqi" className="scroll-mt-24 rounded-2xl bg-white p-5 shadow-lg dark:bg-slate-800 sm:p-6">
+            <IoReaderOutline className="mb-3 h-6 w-6 text-amber-700 dark:text-amber-300" aria-hidden="true" />
+            <h3 className="text-lg font-bold text-amber-800 dark:text-amber-300">Qué mide y qué no mide</h3>
             <ul className="mt-3 space-y-3 text-sm leading-6 text-slate-700 dark:text-slate-300">
-              <li>La hora de medición indica cuándo fue reportada la lectura ambiental.</li>
-              <li>La actualización del pipeline indica cuándo MtyRespira pudo procesar datos.</li>
-              <li>Si un dato externo se retrasa, falta o llega con campos ausentes, la app debe mostrarlo como no disponible o degradado.</li>
-              <li>El histórico usa mediciones guardadas; no calcula valores para huecos ni suaviza datos faltantes.</li>
+              <li>El AQI visible es una lectura externa procesada y normalizada para consulta pública.</li>
+              <li>El contaminante principal se muestra solo cuando la fuente lo reporta; si falta, debe verse como N/D.</li>
+              <li>Las gráficas históricas muestran puntos guardados; los huecos no se rellenan ni se suavizan.</li>
+              <li>MtyRespira no certifica lecturas oficiales ni reemplaza comunicados de emergencia.</li>
             </ul>
           </div>
 
           <div className="rounded-2xl bg-white p-5 shadow-lg dark:bg-slate-800 sm:p-6">
-            <h3 className="text-lg font-bold text-amber-800 dark:text-amber-300">Fuentes y alcance</h3>
+            <h3 className="text-lg font-bold text-amber-800 dark:text-amber-300">Cómo leer una medición</h3>
+            <ul className="mt-3 space-y-3 text-sm leading-6 text-slate-700 dark:text-slate-300">
+              <li><strong>Hora de medición:</strong> cuándo fue reportada la lectura ambiental de origen.</li>
+              <li><strong>Actualización del pipeline:</strong> cuándo MtyRespira pudo procesar datos correctamente.</li>
+              <li><strong>Contexto meteorológico:</strong> si aparece, puede venir de Open-Meteo como fuente secundaria.</li>
+              <li><strong>Estados degradados:</strong> con retraso, vieja o sin lectura indican datos demorados, antiguos o incompletos.</li>
+            </ul>
+          </div>
+
+          <div className="rounded-2xl bg-white p-5 shadow-lg dark:bg-slate-800 sm:p-6">
+            <h3 className="text-lg font-bold text-amber-800 dark:text-amber-300">Fuentes, atribución y alcance</h3>
             <div className="mt-3 space-y-3 text-sm leading-6 text-slate-700 dark:text-slate-300">
               <p>
                 El flujo público es: proveedor externo, pipeline horario, Supabase y lectura en la app.
                 MtyRespira no escribe ni corrige valores ambientales desde el navegador.
               </p>
               <p>
-                AQI: WAQI/AQICN. Los campos de clima pueden retrasarse,
-                omitir campos o degradar su servicio.
+                AQI: World Air Quality Index Project (WAQI/AQICN) y EPA/fuente originadora cuando aplique.
+                Clima: Open-Meteo cuando los campos meteorológicos canónicos están disponibles.
+              </p>
+              <p>
+                La opción para reportar problemas o sugerencias queda pendiente hasta tener una ruta de producto
+                específica; Core DB no se usa para lecturas ambientales.
               </p>
               <div className="flex flex-wrap gap-3 pt-1">
                 <a
                   href={AQICN_API_URL}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="inline-flex rounded-lg border border-amber-300 px-3 py-2 text-sm font-semibold text-amber-800 transition hover:bg-amber-50 dark:border-amber-700 dark:text-amber-200 dark:hover:bg-amber-900/30"
+                  className="inline-flex rounded-lg border border-amber-300 px-3 py-2 text-sm font-semibold text-amber-800 transition hover:bg-amber-50 focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-2 dark:border-amber-700 dark:text-amber-200 dark:hover:bg-amber-900/30"
                 >
                   WAQI/AQICN
+                </a>
+                <a
+                  href={OPEN_METEO_URL}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex rounded-lg border border-sky-300 px-3 py-2 text-sm font-semibold text-sky-800 transition hover:bg-sky-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-2 dark:border-sky-700 dark:text-sky-200 dark:hover:bg-sky-900/30"
+                >
+                  Open-Meteo
                 </a>
               </div>
             </div>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -217,10 +217,10 @@ export default function Layout({ children }: LayoutProps) {
                 Acerca de
               </Link>
               <Link
-                to="/datos-y-apis"
+                to="/datos-y-apis#metodologia-y-limites"
                 className={`px-3 py-2 rounded-md ${location.pathname === '/datos-y-apis' ? 'bg-white/20' : 'hover:bg-white/10'} text-white transition-colors`}
               >
-                Metodología
+                Fuentes
               </Link>
               <Link
                 to="/asociaciones"
@@ -310,8 +310,8 @@ export default function Layout({ children }: LayoutProps) {
                 <Link to="/acerca-de" className="block px-3 py-2 rounded-md hover:bg-gray-100 dark:hover:bg-gray-800">
                   Acerca de
                 </Link>
-                <Link to="/datos-y-apis" className="block px-3 py-2 rounded-md hover:bg-gray-100 dark:hover:bg-gray-800">
-                  Metodología
+                <Link to="/datos-y-apis#metodologia-y-limites" className="block px-3 py-2 rounded-md hover:bg-gray-100 dark:hover:bg-gray-800">
+                  Fuentes y metodología
                 </Link>
                 <Link to="/asociaciones" className="block px-3 py-2 rounded-md hover:bg-gray-100 dark:hover:bg-gray-800">
                   Asociaciones
@@ -340,10 +340,10 @@ export default function Layout({ children }: LayoutProps) {
               </Link>
               {' · '}
               <Link
-                to="/datos-y-apis"
+                to="/datos-y-apis#metodologia-y-limites"
                 className="text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300 transition-colors"
               >
-                Metodología
+                Fuentes y metodología
               </Link>
               {' · '}
               <Link
@@ -404,11 +404,11 @@ export default function Layout({ children }: LayoutProps) {
               <span className="text-[0.68rem]">Acerca de</span>
             </Link>
             <Link
-              to="/datos-y-apis"
+              to="/datos-y-apis#metodologia-y-limites"
               className={`flex flex-col items-center justify-center ${location.pathname === '/datos-y-apis' ? getBottomNavActiveClass() : 'text-gray-500'}`}
             >
               <IoLayersOutline className="mb-0.5 text-lg" />
-              <span className="text-[0.68rem]">Datos</span>
+              <span className="text-[0.68rem]">Fuentes</span>
             </Link>
             <Link
               to="/asociaciones"

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -139,7 +139,7 @@ export default function Dashboard() {
         </div>
       )}
 
-      <div className="grid grid-cols-1 gap-2 lg:grid-cols-3 lg:gap-6">
+      <div id="datos" className="grid scroll-mt-24 grid-cols-1 gap-2 lg:grid-cols-3 lg:gap-6">
         <div className="flex flex-col gap-2 lg:col-span-2 lg:gap-6">
           <AirQualityCard data={airQualityData} />
           <CityHistoricalTrend cityId={selectedCity.city_id} cityName={selectedCity.name} />
@@ -262,28 +262,6 @@ export default function Dashboard() {
               </div>
             </motion.div>
           </a>
-        </div>
-      </div>
-
-      <div className="mt-8 rounded-2xl bg-white p-4 shadow-lg dark:bg-slate-800 sm:mt-6 sm:p-6">
-        <h2 className="mb-3 text-[1.05rem] font-bold text-gray-900 dark:text-white sm:mb-4 sm:text-xl">Fuentes de Datos</h2>
-
-        <div className="text-sm text-gray-600 dark:text-gray-400">
-          <p>Esta aplicacion muestra lecturas disponibles de proveedores externos y las presenta con estados de frescura.</p>
-
-          <ul className="mt-3 list-disc space-y-2 pl-5">
-            <li>
-              <strong>WAQI/AQICN:</strong> Proveedor activo para lecturas AQI de estaciones verificadas.
-              <a href="https://aqicn.org/api/" target="_blank" rel="noopener noreferrer" className={`ml-1 hover:underline ${getStatusBorderClass().replace('border-', 'text-')}`}>Ver API</a>
-            </li>
-            <li>
-              <strong>Campos meteorologicos:</strong> Se muestran como contexto cuando vienen en la lectura disponible.
-            </li>
-          </ul>
-
-          <p className={`mt-4 rounded-lg p-3 ${getStatusButtonClass().replace('bg-', 'bg-').replace('hover:bg-', 'bg-').replace('text-white', `bg-opacity-10 ${getStatusBorderClass().replace('border-', 'text-')}`)}`}>
-            La tarjeta principal muestra la hora de medicion y la ultima actualizacion del pipeline cuando aplica. Los datos externos pueden retrasarse, faltar o llegar con campos ausentes.
-          </p>
         </div>
       </div>
     </Layout>


### PR DESCRIPTION
## Summary
- Hardens the public “Fuentes y metodología” layer introduced by PR #42 instead of duplicating it.
- Adds clearer user-facing copy for AQI source, weather context, measurement vs pipeline update, degraded states, attribution, and limits.
- Wires methodology access from desktop nav, mobile menu, mobile bottom nav, footer, and the Home compact explainer.
- Adds a stable `#datos` anchor for the internal “Ver datos” CTA.
- Documents the public methodology rules in `docs/freshness-truth-ux.md`, including the decision not to invent a problem/suggestion CTA until a specific Core DB `submit_signal` integration exists.

## Area touched
- app: React UI/copy/navigation only.
- pipeline: read-only reference review only; no changes.
- Supabase RPC: no changes to `get_latest_air_quality_per_city` or historical RPCs.
- BD MtyRespira: no writes, DDL, migrations, or data edits.
- Core DB: no new writes; existing product-signal boundary preserved.
- UX: public trust/methodology access, attribution, and degraded-state explanation.
- Cloudflare: no config changes; remains static Vite frontend compatible.

## Contract impact
- No data-contract shape change.
- No AQI/provider behavior change.
- No weather/provider behavior change.
- No geolocation behavior change.
- No Supabase schema/RPC/runtime change.
- Public copy keeps `reading_timestamp` as measurement time and `last_successful_update_at` as pipeline traceability.
- Public copy separates WAQI/AQICN AQI from Open-Meteo weather context.

## Validation
- Connector validation: `get_repo elelier/monterrey-respira` returned the correct repo.
- Reviewed canonical docs: `AGENTS.md`, `docs/roadmap.md`, `docs/PRD.md`, `docs/architecture.md`, `docs/shared-data-contract.md`, `docs/freshness-truth-ux.md`, `docs/style-guide.md`.
- Reviewed PR #42 post-merge state and reused its methodology surface.
- Read-only reference review of `elelier/airquality_pipeline` README confirmed WAQI/AQICN active provider, hourly GitHub Actions cadence, service role pipeline-only boundary, and WAQI attribution requirement.
- Not run locally: connector session cannot execute `npm run lint`, `npm run typecheck`, or `npm run build`.

## Manual QA notes for reviewer
- Check `/` at mobile width: compact methodology explainer is visible and “Leer metodología” routes to `/datos-y-apis#metodologia-y-limites`.
- Check `/datos-y-apis#metodologia-y-limites`: full methodology explains source, limits, stale/old/unavailable states, and attribution.
- Check desktop nav/footer and mobile bottom nav labels do not truncate or overflow.

## Risks / pending items
- Existing lint/build warnings from PR #42 may still exist; this PR does not address legacy warnings.
- The public “Reportar problema/sugerencia” CTA remains intentionally pending because no dedicated signal kind/integration was found for this story.
- Attribution wording is stronger but should be reviewed for exact legal/public wording if formal WAQI branding requirements are later adopted.

## Rollback
- Revert commits on `ux/public-source-methodology-hardening`. No database, pipeline, provider, RPC, Core DB, or Cloudflare rollback is required.