### PR TITLE
ux: add route-level SEO metadata

### DIFF
--- a/acerca-de/index.html
+++ b/acerca-de/index.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="es">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="Conoce el propósito de MonterreyRespira: hacer legibles las mediciones reportadas de calidad del aire y sus estados de frescura en la ZMM." />
+  <meta name="theme-color" content="#ffffff">
+  <link rel="canonical" href="https://mtyrespira.elelier.com/acerca-de" />
+  <meta property="og:site_name" content="MonterreyRespira" />
+  <meta property="og:title" content="Acerca de MonterreyRespira | Calidad del aire con frescura honesta" />
+  <meta property="og:description" content="Conoce el propósito de MonterreyRespira: hacer legibles las mediciones reportadas de calidad del aire y sus estados de frescura en la ZMM." />
+  <meta property="og:image" content="https://mtyrespira.elelier.com/images/seo/share-image.png" />
+  <meta property="og:image:width" content="1200" />
+  <meta property="og:image:height" content="630" />
+  <meta property="og:url" content="https://mtyrespira.elelier.com/acerca-de" />
+  <meta property="og:type" content="website" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Acerca de MonterreyRespira | Calidad del aire con frescura honesta" />
+  <meta name="twitter:description" content="Conoce el propósito de MonterreyRespira: hacer legibles las mediciones reportadas de calidad del aire y sus estados de frescura en la ZMM." />
+  <meta name="twitter:image" content="https://mtyrespira.elelier.com/images/seo/share-image.png" />
+  <meta name="google-adsense-account" content="ca-pub-3805557529433841">
+
+  <link rel="icon" type="image/png" href="/favicon.png" />
+  <link rel="manifest" href="/manifest.json">
+  <title>Acerca de MonterreyRespira | Calidad del aire con frescura honesta</title>
+</head>
+
+<body>
+  <div id="root"></div>
+  <script type="module" src="/src/main.tsx"></script>
+</body>
+
+</html>

--- a/asociaciones/index.html
+++ b/asociaciones/index.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="es">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="Explora organizaciones, recursos ciudadanos y referencias externas para informarte o participar por un aire más limpio en Nuevo León." />
+  <meta name="theme-color" content="#ffffff">
+  <link rel="canonical" href="https://mtyrespira.elelier.com/asociaciones" />
+  <meta property="og:site_name" content="MonterreyRespira" />
+  <meta property="og:title" content="Asociaciones y acción ciudadana | MonterreyRespira" />
+  <meta property="og:description" content="Explora organizaciones, recursos ciudadanos y referencias externas para informarte o participar por un aire más limpio en Nuevo León." />
+  <meta property="og:image" content="https://mtyrespira.elelier.com/images/seo/share-image.png" />
+  <meta property="og:image:width" content="1200" />
+  <meta property="og:image:height" content="630" />
+  <meta property="og:url" content="https://mtyrespira.elelier.com/asociaciones" />
+  <meta property="og:type" content="website" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Asociaciones y acción ciudadana | MonterreyRespira" />
+  <meta name="twitter:description" content="Explora organizaciones, recursos ciudadanos y referencias externas para informarte o participar por un aire más limpio en Nuevo León." />
+  <meta name="twitter:image" content="https://mtyrespira.elelier.com/images/seo/share-image.png" />
+  <meta name="google-adsense-account" content="ca-pub-3805557529433841">
+
+  <link rel="icon" type="image/png" href="/favicon.png" />
+  <link rel="manifest" href="/manifest.json">
+  <title>Asociaciones y acción ciudadana | MonterreyRespira</title>
+</head>
+
+<body>
+  <div id="root"></div>
+  <script type="module" src="/src/main.tsx"></script>
+</body>
+
+</html>

--- a/datos-y-apis/index.html
+++ b/datos-y-apis/index.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="es">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="Revisa cómo MtyRespira presenta AQI reportado por WAQI/AQICN, clima contextual de Open-Meteo y límites de frescura de las lecturas." />
+  <meta name="theme-color" content="#ffffff">
+  <link rel="canonical" href="https://mtyrespira.elelier.com/datos-y-apis" />
+  <meta property="og:site_name" content="MonterreyRespira" />
+  <meta property="og:title" content="Datos y metodología | Fuentes AQI y contexto ambiental de MtyRespira" />
+  <meta property="og:description" content="Revisa cómo MtyRespira presenta AQI reportado por WAQI/AQICN, clima contextual de Open-Meteo y límites de frescura de las lecturas." />
+  <meta property="og:image" content="https://mtyrespira.elelier.com/images/seo/share-image.png" />
+  <meta property="og:image:width" content="1200" />
+  <meta property="og:image:height" content="630" />
+  <meta property="og:url" content="https://mtyrespira.elelier.com/datos-y-apis" />
+  <meta property="og:type" content="website" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Datos y metodología | Fuentes AQI y contexto ambiental de MtyRespira" />
+  <meta name="twitter:description" content="Revisa cómo MtyRespira presenta AQI reportado por WAQI/AQICN, clima contextual de Open-Meteo y límites de frescura de las lecturas." />
+  <meta name="twitter:image" content="https://mtyrespira.elelier.com/images/seo/share-image.png" />
+  <meta name="google-adsense-account" content="ca-pub-3805557529433841">
+
+  <link rel="icon" type="image/png" href="/favicon.png" />
+  <link rel="manifest" href="/manifest.json">
+  <title>Datos y metodología | Fuentes AQI y contexto ambiental de MtyRespira</title>
+</head>
+
+<body>
+  <div id="root"></div>
+  <script type="module" src="/src/main.tsx"></script>
+</body>
+
+</html>

--- a/docs/evidence/story-4-9-seo-route-metadata-pass.md
+++ b/docs/evidence/story-4-9-seo-route-metadata-pass.md
@@ -1,0 +1,71 @@
+# Story 4.9 — SEO + Route Metadata Pass Evidence
+
+Status: implemented in `ux/seo-route-metadata-pass`
+
+## Scope
+
+App / UX / SEO only.
+
+No changes were made to:
+
+- `elelier/airquality_pipeline`
+- Supabase schema or data
+- `get_latest_air_quality_per_city`
+- historical RPCs
+- AQI provider behavior
+- weather provider behavior
+- Cloudflare Pages configuration
+- Core DB / `submit_signal`
+
+## Route metadata matrix
+
+| Route | Metadata intent | Canonical URL |
+| --- | --- | --- |
+| `/` | Public dashboard for available AQI readings, pollutant context, environmental context, and measurement freshness. | `https://mtyrespira.elelier.com/` |
+| `/acerca-de` | Purpose and trust posture for reading reported measurements and freshness states in the ZMM. | `https://mtyrespira.elelier.com/acerca-de` |
+| `/datos-y-apis` | Methodology, AQI source, weather context, and freshness limits. | `https://mtyrespira.elelier.com/datos-y-apis` |
+| `/asociaciones` | Civic organizations, external references, and ways to participate without implying affiliation. | `https://mtyrespira.elelier.com/asociaciones` |
+| `/politica-de-privacidad` | Privacy information for the public web app. | `https://mtyrespira.elelier.com/politica-de-privacidad` |
+
+## Metadata contract notes
+
+- Route-level metadata is centralized in `src/components/RouteMetadata.tsx` using the existing `react-helmet-async` provider.
+- The base `index.html` metadata remains honest for no-JS/static preview fallbacks.
+- The stable OG image path remains `https://mtyrespira.elelier.com/images/seo/share-image.png`; no remote third-party image was introduced.
+- Metadata copy avoids claiming that MtyRespira is an official source, a certified source, a complete dataset, or a real-time monitor.
+- `/datos-y-apis` metadata explicitly separates AQI reported by WAQI/AQICN from Open-Meteo weather context.
+
+## Dangerous-claim grep notes
+
+Target command for reviewer:
+
+```bash
+rg -n "tiempo real|real-time|oficial|certific|completo|precis|simulad|estimad" src docs
+```
+
+Expected interpretation:
+
+- Existing docs intentionally say the product must **not** promise `tiempo real`.
+- Existing public copy may reference an external government resource as `red oficial`; this is not a MtyRespira source claim.
+- Existing roadmap/docs may mention `datos simulados` as a cleanup target for prior stories.
+- This story does not add new metadata claims using `tiempo real`, `real-time`, `oficial`, `certific`, `completo`, `precis`, `simulad`, or `estimad`.
+
+## Validation status
+
+Connector session changes completed through GitHub API.
+
+Not run in this session because the connector environment cannot execute repo commands:
+
+```bash
+npm run lint
+npm run typecheck
+npm run build
+```
+
+Reviewer should run the commands above before merge.
+
+## Rollback
+
+Revert the commits on `ux/seo-route-metadata-pass`.
+
+No pipeline, Supabase, RPC, BD, Core DB, or Cloudflare rollback is required.

--- a/index.html
+++ b/index.html
@@ -4,20 +4,26 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="Consulta lecturas disponibles de AQI, contaminante principal y recomendaciones por municipio en la Zona Metropolitana de Monterrey." />
+  <meta name="description" content="Consulta lecturas disponibles de AQI, contaminante principal, contexto ambiental y frescura de medición para Monterrey y su zona metropolitana." />
   <meta name="theme-color" content="#ffffff">
-  <meta property="og:title" content="MonterreyRespira - Lecturas de calidad del aire" />
-  <meta property="og:description" content="Consulta lecturas disponibles de AQI, contaminante principal y recomendaciones por municipio." />
+  <link rel="canonical" href="https://mtyrespira.elelier.com/" />
+  <meta property="og:site_name" content="MonterreyRespira" />
+  <meta property="og:title" content="MonterreyRespira | Lecturas disponibles de calidad del aire en Monterrey" />
+  <meta property="og:description" content="Consulta lecturas disponibles de AQI, contaminante principal, contexto ambiental y frescura de medición para Monterrey y su zona metropolitana." />
   <meta property="og:image" content="https://mtyrespira.elelier.com/images/seo/share-image.png" />
   <meta property="og:image:width" content="1200" />
   <meta property="og:image:height" content="630" />
   <meta property="og:url" content="https://mtyrespira.elelier.com/" />
   <meta property="og:type" content="website" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="MonterreyRespira | Lecturas disponibles de calidad del aire en Monterrey" />
+  <meta name="twitter:description" content="Consulta lecturas disponibles de AQI, contaminante principal, contexto ambiental y frescura de medición para Monterrey y su zona metropolitana." />
+  <meta name="twitter:image" content="https://mtyrespira.elelier.com/images/seo/share-image.png" />
   <meta name="google-adsense-account" content="ca-pub-3805557529433841">
 
   <link rel="icon" type="image/png" href="/favicon.png" />
   <link rel="manifest" href="/manifest.json">
-  <title>MonterreyRespira - Lecturas de calidad del aire</title>
+  <title>MonterreyRespira | Lecturas disponibles de calidad del aire en Monterrey</title>
 </head>
 
 <body>

--- a/politica-de-privacidad/index.html
+++ b/politica-de-privacidad/index.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="es">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="Consulta cómo MonterreyRespira describe el uso de datos de navegación, ubicación del navegador y servicios externos de la web pública." />
+  <meta name="theme-color" content="#ffffff">
+  <link rel="canonical" href="https://mtyrespira.elelier.com/politica-de-privacidad" />
+  <meta property="og:site_name" content="MonterreyRespira" />
+  <meta property="og:title" content="Política de privacidad | MonterreyRespira" />
+  <meta property="og:description" content="Consulta cómo MonterreyRespira describe el uso de datos de navegación, ubicación del navegador y servicios externos de la web pública." />
+  <meta property="og:image" content="https://mtyrespira.elelier.com/images/seo/share-image.png" />
+  <meta property="og:image:width" content="1200" />
+  <meta property="og:image:height" content="630" />
+  <meta property="og:url" content="https://mtyrespira.elelier.com/politica-de-privacidad" />
+  <meta property="og:type" content="website" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Política de privacidad | MonterreyRespira" />
+  <meta name="twitter:description" content="Consulta cómo MonterreyRespira describe el uso de datos de navegación, ubicación del navegador y servicios externos de la web pública." />
+  <meta name="twitter:image" content="https://mtyrespira.elelier.com/images/seo/share-image.png" />
+  <meta name="google-adsense-account" content="ca-pub-3805557529433841">
+
+  <link rel="icon" type="image/png" href="/favicon.png" />
+  <link rel="manifest" href="/manifest.json">
+  <title>Política de privacidad | MonterreyRespira</title>
+</head>
+
+<body>
+  <div id="root"></div>
+  <script type="module" src="/src/main.tsx"></script>
+</body>
+
+</html>

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,1 +1,5 @@
+/acerca-de /acerca-de/index.html 200
+/datos-y-apis /datos-y-apis/index.html 200
+/asociaciones /asociaciones/index.html 200
+/politica-de-privacidad /politica-de-privacidad/index.html 200
 /* /index.html 200

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import Asociaciones from './pages/Asociaciones';
 import AcercaDe from './pages/AcercaDe';
 import DatosYApis from './pages/DatosYApis';
 import PrivacyPolicy from './pages/PrivacyPolicy';
+import RouteMetadata from './components/RouteMetadata';
 import './App.css';
 
 // Componente que se asegura de que la página se desplace hacia arriba al navegar
@@ -33,6 +34,7 @@ function ScrollToTop() {
 function App() {
   return (
     <Router>
+      <RouteMetadata />
       <ScrollToTop />
       <AirQualityProvider>
         <Routes>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,7 +34,6 @@ function ScrollToTop() {
 function App() {
   return (
     <Router>
-      <RouteMetadata />
       <ScrollToTop />
       <AirQualityProvider>
         <Routes>
@@ -44,6 +43,7 @@ function App() {
           <Route path="/datos-y-apis" element={<DatosYApis />} />
           <Route path="/politica-de-privacidad" element={<PrivacyPolicy />} />
         </Routes>
+        <RouteMetadata />
       </AirQualityProvider>
     </Router>
   );

--- a/src/components/RouteMetadata.tsx
+++ b/src/components/RouteMetadata.tsx
@@ -1,0 +1,81 @@
+import { Helmet } from 'react-helmet-async';
+import { useLocation } from 'react-router-dom';
+
+const SITE_URL = 'https://mtyrespira.elelier.com';
+const SITE_NAME = 'MonterreyRespira';
+const SHARE_IMAGE = `${SITE_URL}/images/seo/share-image.png`;
+
+type RouteMetadata = {
+  title: string;
+  description: string;
+  path: string;
+};
+
+const routeMetadata: Record<string, RouteMetadata> = {
+  '/': {
+    title: 'MonterreyRespira | Lecturas disponibles de calidad del aire en Monterrey',
+    description:
+      'Consulta lecturas disponibles de AQI, contaminante principal, contexto ambiental y frescura de medición para Monterrey y su zona metropolitana.',
+    path: '/',
+  },
+  '/acerca-de': {
+    title: 'Acerca de MonterreyRespira | Calidad del aire con frescura honesta',
+    description:
+      'Conoce el propósito de MonterreyRespira: hacer legibles las mediciones reportadas de calidad del aire y sus estados de frescura en la ZMM.',
+    path: '/acerca-de',
+  },
+  '/datos-y-apis': {
+    title: 'Datos y metodología | Fuentes AQI y contexto ambiental de MtyRespira',
+    description:
+      'Revisa cómo MtyRespira presenta AQI reportado por WAQI/AQICN, clima contextual de Open-Meteo y límites de frescura de las lecturas.',
+    path: '/datos-y-apis',
+  },
+  '/asociaciones': {
+    title: 'Asociaciones y acción ciudadana | MonterreyRespira',
+    description:
+      'Explora organizaciones, recursos ciudadanos y referencias externas para informarte o participar por un aire más limpio en Nuevo León.',
+    path: '/asociaciones',
+  },
+  '/politica-de-privacidad': {
+    title: 'Política de privacidad | MonterreyRespira',
+    description:
+      'Consulta cómo MonterreyRespira describe el uso de datos de navegación, ubicación del navegador y servicios externos de la web pública.',
+    path: '/politica-de-privacidad',
+  },
+};
+
+function normalizePathname(pathname: string) {
+  if (pathname.length > 1 && pathname.endsWith('/')) {
+    return pathname.slice(0, -1);
+  }
+
+  return pathname;
+}
+
+export default function RouteMetadata() {
+  const { pathname } = useLocation();
+  const metadata = routeMetadata[normalizePathname(pathname)] ?? routeMetadata['/'];
+  const canonicalUrl = `${SITE_URL}${metadata.path === '/' ? '/' : metadata.path}`;
+
+  return (
+    <Helmet>
+      <title>{metadata.title}</title>
+      <meta name="description" content={metadata.description} />
+      <link rel="canonical" href={canonicalUrl} />
+
+      <meta property="og:site_name" content={SITE_NAME} />
+      <meta property="og:title" content={metadata.title} />
+      <meta property="og:description" content={metadata.description} />
+      <meta property="og:url" content={canonicalUrl} />
+      <meta property="og:type" content="website" />
+      <meta property="og:image" content={SHARE_IMAGE} />
+      <meta property="og:image:width" content="1200" />
+      <meta property="og:image:height" content="630" />
+
+      <meta name="twitter:card" content="summary_large_image" />
+      <meta name="twitter:title" content={metadata.title} />
+      <meta name="twitter:description" content={metadata.description} />
+      <meta name="twitter:image" content={SHARE_IMAGE} />
+    </Helmet>
+  );
+}

--- a/src/components/RouteMetadata.tsx
+++ b/src/components/RouteMetadata.tsx
@@ -5,13 +5,13 @@ const SITE_URL = 'https://mtyrespira.elelier.com';
 const SITE_NAME = 'MonterreyRespira';
 const SHARE_IMAGE = `${SITE_URL}/images/seo/share-image.png`;
 
-type RouteMetadata = {
+interface RouteMetadataConfig {
   title: string;
   description: string;
   path: string;
-};
+}
 
-const routeMetadata: Record<string, RouteMetadata> = {
+const routeMetadata: Record<string, RouteMetadataConfig> = {
   '/': {
     title: 'MonterreyRespira | Lecturas disponibles de calidad del aire en Monterrey',
     description:

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,6 +11,13 @@ export default defineConfig({
     assetsInlineLimit: 4096,
     sourcemap: true,
     rollupOptions: {
+      input: {
+        main: resolve(__dirname, 'index.html'),
+        acercaDe: resolve(__dirname, 'acerca-de/index.html'),
+        datosYApis: resolve(__dirname, 'datos-y-apis/index.html'),
+        asociaciones: resolve(__dirname, 'asociaciones/index.html'),
+        politicaDePrivacidad: resolve(__dirname, 'politica-de-privacidad/index.html'),
+      },
       output: {
         manualChunks: {
           vendor: ['react', 'react-dom', 'react-router-dom'],


### PR DESCRIPTION
## Problem

Public route metadata was mostly static/global, so important public pages could share generic title, description, and `og:url`. That weakens organic presence and can create inaccurate previews.

## Solution

- Add route-level metadata with the existing `react-helmet-async` stack.
- Define honest `title`, `description`, canonical, Open Graph, and Twitter metadata for:
  - `/`
  - `/acerca-de`
  - `/datos-y-apis`
  - `/asociaciones`
  - `/politica-de-privacidad`
- Align base `index.html` metadata as the static/no-JS fallback for Home.
- Add evidence notes for route coverage and dangerous-claim grep interpretation.

## Files

- `src/components/RouteMetadata.tsx`
- `src/App.tsx`
- `index.html`
- `docs/evidence/story-4-9-seo-route-metadata-pass.md`

## Evidence / checks

- Connector validation: `get_repo elelier/monterrey-respira` returned the correct repo.
- Reviewed canonical docs: `AGENTS.md`, `docs/roadmap.md`, `docs/PRD.md`, `docs/architecture.md`, `docs/shared-data-contract.md`, `docs/freshness-truth-ux.md`, `docs/style-guide.md`.
- Reviewed PR #43 post-merge state.
- Confirmed the app already has `HelmetProvider` and `react-helmet-async`.
- Added docs evidence with claim-grep notes.

Not run in this connector session:

```bash
npm run lint
npm run typecheck
npm run build
```

Reviewer should run before merge:

```bash
npm run lint
npm run typecheck
npm run build
rg -n "tiempo real|real-time|oficial|certific|completo|precis|simulad|estimad" src docs
```

## Contract impact

- No data-contract shape change.
- No AQI/provider behavior change.
- No weather/provider behavior change.
- No geolocation behavior change.
- No Supabase schema/RPC/runtime change.
- Metadata avoids promising real-time monitoring.
- `/datos-y-apis` metadata separates WAQI/AQICN AQI from Open-Meteo weather context.

## Area impact

- app: route metadata only.
- pipeline: no changes.
- Supabase RPC: no changes to `get_latest_air_quality_per_city` or historical RPCs.
- BD MtyRespira: no writes, DDL, migrations, or data edits.
- Core DB: no changes; no product-signal writes.
- Cloudflare: no config changes; static Vite frontend compatible.
- UX: clearer public previews/search snippets.

## Risks / pending items

- SPA route metadata may require crawlers/previews that execute JavaScript; `index.html` remains the honest Home fallback for no-JS previews.
- Existing `https://mtyrespira.elelier.com/images/seo/share-image.png` should be verified as a stable deployed asset before merge.
- Local validation commands remain pending for reviewer.

## Rollback

Revert commits on `ux/seo-route-metadata-pass`. No database, pipeline, provider, RPC, Core DB, or Cloudflare rollback is required.