### PR TITLE
ux: make recommendations section static

### DIFF
--- a/src/components/AirQualityCard.tsx
+++ b/src/components/AirQualityCard.tsx
@@ -14,7 +14,7 @@ import {
   IoTimeOutline,
   IoWarningOutline,
 } from 'react-icons/io5';
-import { AirQualityData, AirQualityStatus } from '../types';
+import { AirQualityData, AirQualityStatus, MeasurementFreshness } from '../types';
 import {
   getHumidityIcon,
   getMainPollutantIcon,
@@ -28,7 +28,6 @@ import {
 } from '../utils/aqiDesignTokens';
 import {
   formatNullableNumber,
-  formatNullableTimestamp,
   getUnknownStateCopy,
   hasReliableAqi,
 } from '../utils/airQualityDisplay';
@@ -125,6 +124,13 @@ const STATUS_CLASSES: Record<
   },
 };
 
+const FRESHNESS_DOT_CLASSES: Record<MeasurementFreshness, string> = {
+  fresh: 'bg-emerald-300 shadow-[0_0_0_4px_rgba(110,231,183,0.18)]',
+  stale: 'bg-amber-300 shadow-[0_0_0_4px_rgba(252,211,77,0.18)]',
+  old: 'bg-orange-300 shadow-[0_0_0_4px_rgba(253,186,116,0.18)]',
+  unknown: 'bg-slate-300 shadow-[0_0_0_4px_rgba(203,213,225,0.18)]',
+};
+
 function getStatusIcon(status: AirQualityStatus, className: string) {
   switch (status) {
     case 'good':
@@ -142,6 +148,36 @@ function getStatusIcon(status: AirQualityStatus, className: string) {
     default:
       return <IoHelpCircleOutline className={className} aria-label="Sin lectura" />;
   }
+}
+
+function formatCompactTimestamp(value: string | null | undefined) {
+  if (!value) {
+    return 'N/D';
+  }
+
+  const date = new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    return 'N/D';
+  }
+
+  const now = new Date();
+  const isToday = date.toDateString() === now.toDateString();
+  const time = new Intl.DateTimeFormat('es-MX', {
+    hour: 'numeric',
+    minute: '2-digit',
+  }).format(date);
+
+  if (isToday) {
+    return `Hoy, ${time}`;
+  }
+
+  return new Intl.DateTimeFormat('es-MX', {
+    day: 'numeric',
+    month: 'short',
+    hour: 'numeric',
+    minute: '2-digit',
+  }).format(date);
 }
 
 export default function AirQualityCard({ data, className = '' }: AirQualityCardProps) {
@@ -164,8 +200,8 @@ export default function AirQualityCard({ data, className = '' }: AirQualityCardP
     ? getPollutantInfo(data.main_pollutant_us).name
     : 'N/D';
   const freshnessCopy = getFreshnessDisplayCopy(data.measurementFreshness);
-  const measurementTime = reliableAqi ? formatNullableTimestamp(data.timestamp) : 'N/D';
-  const pipelineTime = formatNullableTimestamp(data.last_successful_update_at ?? null);
+  const measurementTime = reliableAqi ? formatCompactTimestamp(data.timestamp) : 'N/D';
+  const pipelineTime = formatCompactTimestamp(data.last_successful_update_at ?? null);
 
   return (
     <motion.section
@@ -174,7 +210,7 @@ export default function AirQualityCard({ data, className = '' }: AirQualityCardP
       aria-label={`Calidad del aire en ${data.location.name}: ${copy.label}`}
     >
       <div
-        className={`relative min-h-[26.25rem] overflow-hidden rounded-[1.35rem] bg-gradient-to-br ${classes.gradient} px-5 py-5 text-white shadow-[0_16px_34px_rgba(15,23,42,0.18)] ring-1 ${classes.ring} sm:min-h-[25rem] sm:rounded-[1.6rem] sm:px-8 sm:py-7`}
+        className={`relative min-h-[24.5rem] overflow-hidden rounded-[1.35rem] bg-gradient-to-br ${classes.gradient} px-5 py-5 text-white shadow-[0_16px_34px_rgba(15,23,42,0.18)] ring-1 ${classes.ring} sm:min-h-[25rem] sm:rounded-[1.6rem] sm:px-8 sm:py-7`}
       >
         <div
           className="absolute inset-0 bg-[url('/images/monterrey-cerro-silla.jpg')] bg-cover bg-[70%_100%] opacity-95"
@@ -243,18 +279,12 @@ export default function AirQualityCard({ data, className = '' }: AirQualityCardP
             </p>
           )}
 
-          <div className="mt-4 grid max-w-[34rem] grid-cols-1 gap-2 sm:grid-cols-2">
-            <InfoPill
-              icon={<IoTimeOutline className="h-6 w-6" />}
-              label={freshnessCopy.label}
-              value={`Medicion ${measurementTime}`}
-            />
-            <InfoPill
-              icon={<IoCloudOutline className="h-6 w-6" />}
-              label="Trazabilidad"
-              value={`Pipeline ${pipelineTime}`}
-            />
-          </div>
+          <FreshnessPill
+            freshness={data.measurementFreshness}
+            label={freshnessCopy.shortLabel}
+            measurementTime={measurementTime}
+            pipelineTime={pipelineTime}
+          />
         </div>
       </div>
 
@@ -339,20 +369,25 @@ export default function AirQualityCard({ data, className = '' }: AirQualityCardP
   );
 }
 
-interface InfoPillProps {
-  icon: React.ReactNode;
+interface FreshnessPillProps {
+  freshness: MeasurementFreshness;
   label: string;
-  value: string;
+  measurementTime: string;
+  pipelineTime: string;
 }
 
-function InfoPill({ icon, label, value }: InfoPillProps) {
+function FreshnessPill({ freshness, label, measurementTime, pipelineTime }: FreshnessPillProps) {
   return (
-    <div className="flex min-w-0 items-center gap-3 rounded-xl bg-white/95 px-3 py-2.5 text-slate-950 shadow-md backdrop-blur-md sm:rounded-2xl sm:px-4 sm:py-3">
-      <span className="shrink-0 text-amber-500 [&>svg]:h-7 [&>svg]:w-7 sm:[&>svg]:h-8 sm:[&>svg]:w-8">{icon}</span>
-      <span className="min-w-0">
-        <span className="block truncate text-[0.78rem] font-semibold text-slate-500 sm:text-sm">{label}</span>
-        <span className="block text-[0.9rem] font-black leading-tight sm:text-lg">{value}</span>
-      </span>
+    <div
+      className="mt-4 inline-flex max-w-full items-center gap-2 rounded-full bg-white/16 px-3 py-2 text-[0.72rem] font-semibold text-white shadow-sm ring-1 ring-white/25 backdrop-blur-md sm:px-4 sm:text-sm"
+      aria-label={`${label}. Medicion ${measurementTime}. Pipeline ${pipelineTime}.`}
+      title={`Pipeline: ${pipelineTime}`}
+    >
+      <span className={`h-2.5 w-2.5 shrink-0 rounded-full ${FRESHNESS_DOT_CLASSES[freshness]}`} aria-hidden="true" />
+      <IoTimeOutline className="h-4 w-4 shrink-0 opacity-80" aria-hidden="true" />
+      <span className="shrink-0">{label}</span>
+      <span className="text-white/55" aria-hidden="true">·</span>
+      <span className="truncate">Medición {measurementTime}</span>
     </div>
   );
 }

--- a/src/components/AirQualityMap.tsx
+++ b/src/components/AirQualityMap.tsx
@@ -261,28 +261,31 @@ export default function AirQualityMap() {
       )}
 
       <div className="mt-4 rounded-2xl border border-slate-200 bg-white p-3 shadow-sm dark:border-slate-700 dark:bg-slate-900 sm:p-4">
-        <h3 className="text-[0.95rem] font-bold text-gray-900 dark:text-white sm:text-base">Escala AQI (US)</h3>
-        <div className="mt-3 grid grid-cols-2 gap-2 text-center text-xs sm:grid-cols-4 lg:grid-cols-7">
+        <div className="flex items-baseline justify-between gap-3">
+          <h3 className="text-[0.95rem] font-bold text-gray-900 dark:text-white sm:text-base">Escala AQI (US)</h3>
+          <p className="text-[0.68rem] text-gray-500 dark:text-gray-400 sm:hidden">US EPA</p>
+        </div>
+        <div className="mt-2 -mx-1 flex gap-1.5 overflow-x-auto px-1 pb-1 text-center text-[0.64rem] sm:mx-0 sm:mt-3 sm:grid sm:grid-cols-4 sm:gap-2 sm:overflow-visible sm:px-0 sm:pb-0 sm:text-xs lg:grid-cols-7">
           {AQI_LEGEND.map((item) => {
             const theme = getAirQualityTheme(item.status);
 
             return (
-              <div key={item.status}>
+              <div key={item.status} className="min-w-[5.2rem] shrink-0 sm:min-w-0 sm:shrink">
                 <div
-                  className="rounded-lg px-2 py-1.5 font-bold text-white"
+                  className="rounded-md px-2 py-1 font-bold text-white sm:rounded-lg sm:py-1.5"
                   style={{ backgroundColor: theme.primary }}
                 >
                   {item.range}
                 </div>
-                <p className="mt-1 font-medium text-gray-700 dark:text-gray-300">
+                <p className="mt-0.5 truncate font-medium text-gray-700 dark:text-gray-300 sm:mt-1 sm:whitespace-normal">
                   {item.shortLabel}
                 </p>
               </div>
             );
           })}
         </div>
-        <p className="mt-3 text-xs text-gray-500 dark:text-gray-400">
-          AQI: Indice de Calidad del Aire bajo escala US EPA.
+        <p className="mt-1 text-[0.65rem] leading-snug text-gray-500 dark:text-gray-400 sm:mt-3 sm:text-xs">
+          AQI bajo escala US EPA.
         </p>
       </div>
     </section>

--- a/src/components/Recommendations.tsx
+++ b/src/components/Recommendations.tsx
@@ -1,6 +1,5 @@
 import {
   IoBicycleOutline,
-  IoChevronForwardOutline,
   IoHelpCircleOutline,
   IoHomeOutline,
   IoLeafOutline,
@@ -10,7 +9,7 @@ import {
   IoWarningOutline,
 } from 'react-icons/io5';
 import { AirQualityStatus } from '../types';
-import { AQI_RECOMMENDATIONS, AQI_THEME_TOKENS } from '../utils/aqiDesignTokens';
+import { AQI_RECOMMENDATIONS } from '../utils/aqiDesignTokens';
 
 interface RecommendationsProps {
   status: AirQualityStatus;
@@ -90,45 +89,44 @@ function getRecommendationIcon(iconName: string, className: string) {
 export default function Recommendations({ status, className = '' }: RecommendationsProps) {
   const recommendations = AQI_RECOMMENDATIONS[status].slice(0, 3);
   const classes = STATUS_CLASSES[status];
-  const theme = AQI_THEME_TOKENS[status];
 
   return (
     <section
-      className={`rounded-[1.15rem] border border-slate-200 bg-white p-1.5 shadow-[0_10px_24px_rgba(15,23,42,0.08)] dark:border-slate-700 dark:bg-slate-800 sm:rounded-[1.35rem] sm:p-4 ${className}`}
+      className={`rounded-[1.15rem] border border-slate-200 bg-white p-3 shadow-[0_10px_24px_rgba(15,23,42,0.08)] dark:border-slate-700 dark:bg-slate-800 sm:rounded-[1.35rem] sm:p-4 ${className}`}
       aria-labelledby="recommendations-title"
     >
-      <div className="mb-1 flex items-center gap-2.5 sm:mb-3 sm:gap-3">
+      <div className="mb-3 flex items-center gap-2.5 sm:mb-4 sm:gap-3">
         <IoLeafOutline className={`h-[1.1rem] w-[1.1rem] ${classes.accent} sm:h-7 sm:w-7`} />
-        <h2 id="recommendations-title" className="text-[0.94rem] font-semibold text-slate-950 dark:text-white sm:text-xl sm:font-black">
-          Recomendaciones
-        </h2>
+        <div>
+          <h2 id="recommendations-title" className="text-[0.94rem] font-semibold leading-tight text-slate-950 dark:text-white sm:text-xl sm:font-black">
+            Recomendaciones
+          </h2>
+          <p className="mt-0.5 text-[0.62rem] leading-tight text-slate-500 dark:text-slate-400 sm:text-sm">
+            Guía rápida según el AQI disponible.
+          </p>
+        </div>
       </div>
 
-      <div className="space-y-1 sm:space-y-2">
+      <ul className="space-y-1.5 sm:space-y-2" aria-label="Recomendaciones de salud y actividad">
         {recommendations.map((recommendation) => (
-          <article
+          <li
             key={`${recommendation.title}-${recommendation.icon}`}
-            className={`grid h-[2.15rem] grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-2 overflow-hidden rounded-lg border ${classes.border} ${classes.bg} px-2 sm:h-auto sm:gap-3 sm:rounded-2xl sm:px-3 sm:py-3`}
+            className={`grid grid-cols-[auto_minmax(0,1fr)] items-start gap-2 rounded-lg border ${classes.border} ${classes.bg} px-2.5 py-2 sm:gap-3 sm:rounded-2xl sm:px-3 sm:py-3`}
           >
-            <div className={`flex h-6 w-6 items-center justify-center rounded-full ${classes.iconBg} sm:h-12 sm:w-12`}>
-              {getRecommendationIcon(recommendation.icon, `h-[0.95rem] w-[0.95rem] ${classes.accent} sm:h-7 sm:w-7`)}
+            <div className={`flex h-7 w-7 shrink-0 items-center justify-center rounded-full ${classes.iconBg} sm:h-12 sm:w-12`}>
+              {getRecommendationIcon(recommendation.icon, `h-4 w-4 ${classes.accent} sm:h-7 sm:w-7`)}
             </div>
             <div className="min-w-0">
-              <h3 className="truncate text-[0.72rem] font-medium leading-tight text-slate-950 dark:text-white sm:text-base sm:font-black">
+              <h3 className="text-[0.76rem] font-semibold leading-tight text-slate-950 dark:text-white sm:text-base sm:font-black">
                 {recommendation.title}
               </h3>
-              <p className="line-clamp-1 text-[0.56rem] leading-tight text-slate-600 dark:text-slate-300 sm:line-clamp-2 sm:text-sm">
+              <p className="mt-0.5 text-[0.62rem] leading-snug text-slate-600 dark:text-slate-300 sm:text-sm">
                 {recommendation.description}
               </p>
             </div>
-            <IoChevronForwardOutline
-              className="h-4 w-4 shrink-0 sm:h-6 sm:w-6"
-              style={{ color: theme.secondary }}
-              aria-hidden="true"
-            />
-          </article>
+          </li>
         ))}
-      </div>
+      </ul>
     </section>
   );
 }

--- a/src/utils/freshness.ts
+++ b/src/utils/freshness.ts
@@ -73,18 +73,18 @@ export function getFreshnessDisplayCopy(freshness: MeasurementFreshness): Freshn
   switch (freshness) {
     case 'fresh':
       return {
-        label: 'Medición de hoy',
-        shortLabel: 'Hoy',
+        label: 'Medición vigente',
+        shortLabel: 'Actual',
       };
     case 'stale':
       return {
         label: 'Medición con retraso',
-        shortLabel: 'Retraso +12 h',
+        shortLabel: '+12 h',
       };
     case 'old':
       return {
         label: 'Dato viejo',
-        shortLabel: 'Viejo +24 h',
+        shortLabel: '+24 h',
       };
     default:
       return {

--- a/src/utils/freshness.ts
+++ b/src/utils/freshness.ts
@@ -1,7 +1,7 @@
 import { MeasurementFreshness } from '../types';
 
-export const FRESHNESS_STALE_THRESHOLD_HOURS = 2;
-export const FRESHNESS_OLD_THRESHOLD_HOURS = 6;
+export const FRESHNESS_STALE_THRESHOLD_HOURS = 12;
+export const FRESHNESS_OLD_THRESHOLD_HOURS = 24;
 const FUTURE_CLOCK_SKEW_TOLERANCE_HOURS = 5 / 60;
 
 export interface FreshnessDisplayCopy {
@@ -61,7 +61,7 @@ export function getMeasurementFreshnessReason(
     case 'old':
       return `Dato viejo para ${cityName}; revisar con cautela.`;
     case 'stale':
-      return `La medición ambiental de ${cityName} tiene retraso frente a la cadencia esperada.`;
+      return `La medición ambiental de ${cityName} tiene más de 12 horas.`;
     case 'unknown':
       return `No se pudo validar la hora de medición ambiental para ${cityName}.`;
     default:
@@ -73,18 +73,18 @@ export function getFreshnessDisplayCopy(freshness: MeasurementFreshness): Freshn
   switch (freshness) {
     case 'fresh':
       return {
-        label: 'Medición reciente',
-        shortLabel: 'Reciente',
+        label: 'Medición de hoy',
+        shortLabel: 'Hoy',
       };
     case 'stale':
       return {
         label: 'Medición con retraso',
-        shortLabel: 'Con retraso',
+        shortLabel: 'Retraso +12 h',
       };
     case 'old':
       return {
         label: 'Dato viejo',
-        shortLabel: 'Viejo',
+        shortLabel: 'Viejo +24 h',
       };
     default:
       return {


### PR DESCRIPTION
## Resumen
- Quita los chevrons de las recomendaciones.
- Presenta la sección como lista informativa estática.
- Compacta la escala AQI en mobile con scroll horizontal.
- Sustituye las dos tarjetas grandes de medición/pipeline por una sola lectura tenue tipo status pill.
- Si la medición es del día actual, muestra `Hoy, hora` para reducir ruido y confusión.
- Ajusta frescura: `retraso` solo aparece después de 12 horas; `viejo` después de 24 horas.
- Reduce repetición visual: estado normal ahora dice `Actual`, no `Hoy · Medición Hoy...`.

## Alcance
Solo app/UI pública y lógica de clasificación visual de frescura. No toca pipeline, BD, AQI ni contratos de datos.

## Validación
Revisión estática de componentes. No ejecuté build/tests desde el conector.